### PR TITLE
Simple addition to the default included directories in DFLAGS

### DIFF
--- a/linux/dmd_arch.sh
+++ b/linux/dmd_arch.sh
@@ -227,9 +227,9 @@ echo -e ';
 [Environment]
 ' > etc/dmd.conf
 if [ "$UNZIPDIR" = "dmd2" ]; then
-	echo "DFLAGS=-I/usr/include/d/dmd/phobos -I/usr/include/d/dmd/druntime/import -L-L/usr/lib -L--no-warn-search-mismatch -L--export-dynamic" >> etc/dmd.conf
+	echo "DFLAGS=-I/usr/include/d -I/usr/include/d/dmd/phobos -I/usr/include/d/dmd/druntime/import -L-L/usr/lib -L--no-warn-search-mismatch -L--export-dynamic" >> etc/dmd.conf
 else
-	echo "DFLAGS=-I/usr/include/d/dmd/phobos -L-L/usr/lib -L--no-warn-search-mismatch -L--export-dynamic" >> etc/dmd.conf
+	echo "DFLAGS=-I/usr/include/d -I/usr/include/d/dmd/phobos -L-L/usr/lib -L--no-warn-search-mismatch -L--export-dynamic" >> etc/dmd.conf
 fi
 
 

--- a/linux/dmd_deb.sh
+++ b/linux/dmd_deb.sh
@@ -221,7 +221,7 @@ echo '; ' >> etc/dmd.conf
 echo >> etc/dmd.conf
 echo '[Environment]' >> etc/dmd.conf
 echo >> etc/dmd.conf
-echo -n 'DFLAGS=-I/usr/include/d/dmd/phobos' >> etc/dmd.conf
+echo -n 'DFLAGS=-I/usr/include/d -I/usr/include/d/dmd/phobos' >> etc/dmd.conf
 if [ "$UNZIPDIR" = "dmd2" ]; then
 	echo -n ' -I/usr/include/d/dmd/druntime/import' >> etc/dmd.conf
 fi

--- a/linux/dmd_rpm.sh
+++ b/linux/dmd_rpm.sh
@@ -226,7 +226,7 @@ echo '; ' >> etc/dmd.conf
 echo >> etc/dmd.conf
 echo '[Environment]' >> etc/dmd.conf
 echo  >> etc/dmd.conf
-echo -n 'DFLAGS=-I/usr/include/d/dmd/phobos' >> etc/dmd.conf
+echo -n 'DFLAGS=-I/usr/include/d -I/usr/include/d/dmd/phobos' >> etc/dmd.conf
 if [ "$UNZIPDIR" = "dmd2" ]; then
 	echo -n ' -I/usr/include/d/dmd/druntime/import' >> etc/dmd.conf
 fi

--- a/osx/dmd.conf
+++ b/osx/dmd.conf
@@ -1,4 +1,4 @@
 
 [Environment]
 
-DFLAGS=-I/usr/share/dmd/src/phobos -L-L/usr/share/dmd/lib
+DFLAGS=-I/usr/include/d -I/usr/share/dmd/src/phobos -L-L/usr/share/dmd/lib

--- a/osx/dmd2.conf
+++ b/osx/dmd2.conf
@@ -1,4 +1,4 @@
 
 [Environment]
 
-DFLAGS=-I/usr/share/dmd/src/phobos -I/usr/share/dmd/src/druntime/import -L-L/usr/share/dmd/lib
+DFLAGS=-I/usr/include/d -I/usr/share/dmd/src/phobos -I/usr/share/dmd/src/druntime/import -L-L/usr/share/dmd/lib

--- a/rpmsrc/dmd.conf
+++ b/rpmsrc/dmd.conf
@@ -1,4 +1,4 @@
 
 [Environment]
 
-DFLAGS= -L-L/usr/lib -I/usr/include/d/dmd/phobos -I/usr/include/d/dmd/druntime/import -L-lrt
+DFLAGS=-I/usr/include/d  -L-L/usr/lib -I/usr/include/d/dmd/phobos -I/usr/include/d/dmd/druntime/import -L-lrt


### PR DESCRIPTION
Adding -I/usr/include/d allows users who write libraries with accompanying .di files or just a source library to be able to make a simple install script that will install their modules or packages to /usr/include/d so the user of the library won't have to bother to -Include it every time.
