### PR TITLE
Make D1 unchecked by default

### DIFF
--- a/windows/dinstaller.nsi
+++ b/windows/dinstaller.nsi
@@ -94,7 +94,7 @@ CRCCheck force
 ; registry entries, etc.
 ;--------------------------------------------------------
 
-Section "D 1" Dmd1Files
+Section /o "D 1" Dmd1Files
 
     ; This section is mandatory
     ;SectionIn RO


### PR DESCRIPTION
New users sometimes have difficulty because they've installed both versions of D which places both in their path, which means they sometimes try to compile D2 code with D1.

This makes the D1 install option unchecked by default.  I believe this will help new users who are just learning D and might not known the difference between the versions. It also reflects that D1, while available and easily installed, isn't suggested for new users writing new code.
