### PR TITLE
Fix issue with PackageMaker not being bundled with Xcode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+osx/dmd
+osx/dmg
+*.dmg

--- a/osx/make.rb
+++ b/osx/make.rb
@@ -13,11 +13,10 @@ include FileUtils
 
 class PackageMaker
 	attr_accessor :path, :output
-	
+
 	def make
 		dmd = ""
 		dmd_conf = ""
-		packagemaker = '/Developer/usr/bin/packagemaker'
 		version = 0
 
 		rm_rf "dmd"
@@ -49,7 +48,13 @@ class PackageMaker
 		`hdiutil create -srcfolder dmg/#{dmd} #{@output}.dmg` unless @output.nil?
 		`hdiutil create -srcfolder dmg/#{dmd} dmd.dmg` if @output.nil? && version == 1
 		`hdiutil create -srcfolder dmg/#{dmd} dmd2.dmg` if @output.nil? && version == 2
-	end	
+	end
+
+	def packagemaker
+		return @packagemaker if @packagemaker
+		path = '/Developer/usr/bin/packagemaker'
+		@packagemaker = File.exist?(path) ? path : "/Applications/PackageMaker.app/Contents/MacOS/PackageMaker"
+	end
 end
 
 # Prints the message to stderr, exits


### PR DESCRIPTION
PackageMaker is apparently not included with Xcode anymore. It's not included in the auxiliary package which can be downloaded here:

https://developer.apple.com/downloads/index.action

The script now assumes PackageMaker is installed either in `/Applications/PackageMaker.app/Contents/MacOS/PackageMaker` or, as before, `/Developer/usr/bin/packagemaker`.
