### PR TITLE
Created a no-dependency script to bootstrap Windows DMD.

### DIFF
--- a/bootstrap/bootstrap-dmd.bat
+++ b/bootstrap/bootstrap-dmd.bat
@@ -45,8 +45,8 @@ set REAL_GIT_SCRIPT=%SCRAP_DIR%\real-git.bat
 set UNZIP_DIR=%SCRAP_DIR%\unzip
 set UNZIP_CMD=%UNZIP_DIR%\unzip.exe -q
 set DM_BIN=%WORK_DIR%\dm\bin
-set DMD_BIN=%WORK_DIR%\dmd\bin32
-set DMD_LIB=%WORK_DIR%\dmd\lib32
+set DMD_BIN=%WORK_DIR%\dmd\bin
+set DMD_LIB=%WORK_DIR%\dmd\lib
 
 rem Fresh start
 rmdir /S /Q "%WORK_DIR%" 2> NUL
@@ -164,7 +164,7 @@ copy %DM_BIN%\..\lib\*.lib %DMD_LIB%
 rem Generate sc.ini
 rem -------------------------------------------------------------------------
 echo.[Environment]                                                   >  %DMD_BIN%\sc.ini
-echo.LIB="%%@P%%\..\lib32"                                           >> %DMD_BIN%\sc.ini
+echo.LIB="%%@P%%\..\lib"                                             >> %DMD_BIN%\sc.ini
 echo.DFLAGS="-I%%@P%%\..\..\phobos" "-I%%@P%%\..\..\druntime\import" >> %DMD_BIN%\sc.ini
 echo.LINKCMD=%%@P%%\link.exe                                         >> %DMD_BIN%\sc.ini
 rem -------------------------------------------------------------------------


### PR DESCRIPTION
While this pull is just for Windows, a Posix version is in the works.

This is a one-file tool that has _no_ prerequisites other than an internet connection and a working Windows machine (XP and up - untested on 2k). It will use Git if it's detected, but does not require it. The only other dependencies (DMC and a command-line unzip) are automatically downloaded by this script (but not installed system-wide, just placed in a subdirectory).

One nice effect of the above is that, if this pull is merged, any internet-connected Windows user who has [wget](http://gnuwin32.sourceforge.net/packages/wget.htm) installed can go from having _no_ DMD whatsoever to a basic bootstrapped DMD with nothing more than one command:

```
wget https://raw.github.com/D-Programming-Language/installer/master/bootstrap/bootstrap-dmd.bat && bootstrap-dmd
```

(However, this script does _not_ require wget or curl.)

This script is _deliberately_ limited to building and setting up nothing more than Win32 DMD, Druntime, Phobos and RDMD. My intention is with that much bootstrapped by this batch file, any further tasks can be implemented _in_ D.

I tested this on WinXP 32-bit and Win7 64-bit, and also from arbitrary directories (it not just the directory with the script), and inside paths containing spaces.

BTW, I put it in it's own separate "bootstrap" subdirectory because my intention is to also have an equivalent Posix script plus D-based cross-platform "stage 2" files. Using this common directory ensures both Windows and Posix users can run the script using the same command: `"path"~dirSep~"boostrap-dmd"`
