### PR TITLE
[2.065] remove -L--no-warn-search-mismatch

### DIFF
--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -740,7 +740,7 @@ void buildAll(Bits bits, bool dmdOnly=false)
         version(OSX)
             enum flags="";
         else
-            enum flags=" -L--no-warn-search-mismatch -L--export-dynamic";
+            enum flags=" -L--export-dynamic";
 
         std.file.write(cloneDir~"/dmd/src/dmd.conf", (`
             [Environment]


### PR DESCRIPTION
- Not available for FreeBSD linker.
- Not needed because we only use the correct phobos lib dir.
