### PR TITLE
[install] fix setting file attributes after zip extraction

### DIFF
--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -1481,6 +1481,9 @@ string[] gitVersionedFiles(string path)
 void extract(string archive, string outputDir)
 {
     import std.zip;
+    version (Posix) import core.sys.posix.sys.stat : setFileAttributes = chmod;
+    else version (Windows) import core.sys.windows.windows : setFileAttributes = SetFileAttributes;
+    else static assert(0, "unsupported platform");
 
     infoMsg("Extracting "~displayPath(archive));
 
@@ -1497,6 +1500,7 @@ void extract(string archive, string outputDir)
         if(verbose)
             infoMsg(path);
         std.file.write(path, am.expandedData);
+        setFileAttributes(toStringz(path), am.fileAttributes);
     }
 }
 


### PR DESCRIPTION
- otherwise the combine step looses the executable flag

Depens on: https://github.com/D-Programming-Language/druntime/pull/696.
