### PR TITLE
[2.065] fix Issue 11799 - Incompatible argument types in create_dmd_release

### DIFF
--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -1481,9 +1481,6 @@ string[] gitVersionedFiles(string path)
 void extract(string archive, string outputDir)
 {
     import std.zip;
-    version (Posix) import core.sys.posix.sys.stat : setFileAttributes = chmod;
-    else version (Windows) import core.sys.windows.windows : setFileAttributes = SetFileAttributes;
-    else static assert(0, "unsupported platform");
 
     infoMsg("Extracting "~displayPath(archive));
 
@@ -1500,7 +1497,7 @@ void extract(string archive, string outputDir)
         if(verbose)
             infoMsg(path);
         std.file.write(path, am.expandedData);
-        setFileAttributes(toStringz(path), am.fileAttributes);
+        std.file.setAttributes(path, am.fileAttributes);
     }
 }
 


### PR DESCRIPTION
- use std.file.setFileAttributes
