### PR TITLE
Remove multiple Version2 definition

### DIFF
--- a/create_dmd_release/build_all.d
+++ b/create_dmd_release/build_all.d
@@ -287,7 +287,7 @@ void runBuild(Box box, string gitTag, bool combine)
     {
         sh = box.shell();
         sh.stdin.writeln(`cd clones\installer\windows`);
-        sh.stdin.writeln(`&'C:\Program Files (x86)\NSIS\makensis' /DVersion2=`~ver~` dinstaller.nsi`);
+        sh.stdin.writeln(`&'C:\Program Files (x86)\NSIS\makensis' dinstaller.nsi`);
         sh.stdin.writeln(`copy dmd-`~ver~`.exe C:\Users\vagrant\dmd-`~ver~`.exe`);
         sh.close();
         box.scp("default:dmd-"~ver~".exe", ".");


### PR DESCRIPTION
Remove Version2 variable definition when calling dinstaller.nsi. Already defined in dinstaller.nsi.
