### PR TITLE
Change gcc-multilib to recommends in deb-packages

### DIFF
--- a/linux/dmd_deb.sh
+++ b/linux/dmd_deb.sh
@@ -290,7 +290,8 @@ else
 
 
 	# set deb package dependencies
-	DEPENDS="libc6, libc6-dev, gcc, gcc-multilib, libgcc1, libstdc++6, xdg-utils, libcurl3"
+	DEPENDS="libc6, libc6-dev, gcc, libgcc1, libstdc++6, xdg-utils, libcurl3"
+	RECOMMENDS="gcc-multilib"
 	SUGGESTS="libcurl4-openssl-dev"
 
 
@@ -301,6 +302,7 @@ else
 	Maintainer: '$MAINTAINER'
 	Installed-Size: '$(du -ks usr/ | awk '{print $1}')'
 	Depends: '$DEPENDS'
+	Recommends:'$RECOMMENDS'
 	Suggests: '$SUGGESTS'
 	Provides: '$UNZIPDIR-$MINOR'
 	Section: devel


### PR DESCRIPTION
The gcc-multilib package is not required for dmd to work on 64-bit
systems when 32-bit software is not going to be built. Changing from
'Depends' to 'Recommends' still suggest a strong connection but it will
be possible to choose not to install gcc-multilib.

According to the Debian Policy Manual 'Recommends' still states the packages should be installed together during normal conditions. In my case I ran into problems and though a more relaxed dependency chain would be beneficial.
https://www.debian.org/doc/debian-policy/ch-relationships.html#s-binarydeps
