### PR TITLE
Update create_dmd_release.d

### DIFF
--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -558,7 +558,7 @@ void init(string branch)
             if(!exists(msvcBinDir~"cl.exe"))
                 msvcBinDir = win64vcDir ~ "/bin/amd64";
 
-            ensureTool(quote(msvcBinDir~"/cl.exe"), "/?");
+            ensureTool(quote(msvcBinDir~"/cl.exe"), "/HELP");
             try
             {
                 ensureDir(win64sdkDir);


### PR DESCRIPTION
/? option of cl.exe results in ICE using /HELP instead.
