### PR TITLE
Port Windows installer features from linux\win version

### DIFF
--- a/windows/dinstaller.nsi
+++ b/windows/dinstaller.nsi
@@ -192,7 +192,7 @@ SectionGroup /e "D2"
 Section "-D2" Dmd2Files
 
     ; This section is mandatory
-    ;SectionIn RO
+    SectionIn RO
 
     SetOutPath $INSTDIR
 


### PR DESCRIPTION
@jordisayol asked me to port these over. Here is his description of them.
- allow run only one dmd installer at a time.
- include the dmd version on the installer itself and not only on the installer file name. This allow to set the dmd version on system registry, and so, the newer installers can detect which dmd version is currently installed on system.
- control if another dmd is already installed on the system, advertise the user and allow to remove before to install dmd or exit the installation. Two dmd installed together on the same place has no sense and should be a source of problems.
- to properly control if another dmd is already installed, properly set on install and unset on remove all the appropriated entries on system registry.
- allow to force install (from command line) if there is a dmd installation information on system registry but the uninstaller cannot be run (corrupted or removed).
- when upgrading from a previous dmd installation, use the same base directory by default.

I **did not** do the following he asked me about:
- include all the files in the installer itself and not download on every installation (needs to be integrated with release process and I haven't had time to grok how it works yet).
- disable "next" button on selection screen if nothing is selected (I just made D2 installation mandatory)
- when uninstalling, remove the "dmd2" and "dmc" folders even if the user added some files/folder on them, but keep the base folder (i.e. "c:\dmd") if it's not empty after remove these two folders (I had done this previously).
