### PR TITLE
Embed "dmd2" folder, not its parent

### DIFF
--- a/create_dmd_release/build_all.d
+++ b/create_dmd_release/build_all.d
@@ -300,7 +300,7 @@ void runBuild(Box box, string gitTag, bool combine)
         sh = box.shell();
         sh.stdin.writeln(`cd clones\installer\windows`);
         sh.stdin.writeln(`&'C:\Program Files (x86)\NSIS\makensis'`~
-                         ` '/DEmbedD2Dir=C:\Users\vagrant\dmd.`~gitTag~`.windows'`~
+                         ` '/DEmbedD2Dir=C:\Users\vagrant\dmd.`~gitTag~`.windows\dmd2'`~
                          ` '/DVersion2=`~ver~`' d2-installer.nsi`);
         sh.stdin.writeln(`copy dmd-`~ver~`.exe C:\Users\vagrant\dmd-`~ver~`.exe`);
         sh.close();


### PR DESCRIPTION
The beta installer was putting everything in `C:\D\dmd.v2.066.0-b6.windows` rather than `C:\D`.
