### PR TITLE
move xdg-utils from Depends to Suggests

### DIFF
--- a/linux/dmd_deb.sh
+++ b/linux/dmd_deb.sh
@@ -344,8 +344,8 @@ else
 
 
 	# set deb package dependencies
-	DEPENDS="libc6, libc6-dev, gcc, libgcc1, libstdc++6, xdg-utils, libcurl3"
-	SUGGESTS="libcurl4-openssl-dev, gcc-multilib"
+	DEPENDS="libc6, libc6-dev, gcc, libgcc1, libstdc++6, libcurl3"
+	SUGGESTS="libcurl4-openssl-dev, gcc-multilib, xdg-utils"
 
 
 	# create control file


### PR DESCRIPTION
- fixes the problem that dmd currently installs a complete X11 server

- only needed for browser/desktop related functionality, e.g. dman, or
  std.phobos.brower open, it's OK when those don't work on a headless server