### PR TITLE
fix Issue 16794 - .deb no working on Ubuntu 16.10

### DIFF
--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -430,6 +430,11 @@ void buildAll(Bits bits, string branch, bool dmdOnly=false)
     auto hostDMDEnv = " HOST_DC="~hostDMD;
     auto isRelease = " RELEASE=1";
     auto latest = " LATEST="~branch;
+    // PIC libraries on amd64 for PIE-by-default distributions, see Bugzilla 16794
+    version (linux)
+        auto pic = bits == Bits.bits64 ? " PIC=1" : "";
+    else
+        auto pic = "";
 
     // common make arguments
     auto makecmd = make~jobs~makeModel~dmdEnv~hostDMDEnv~isRelease~latest~" -f "~targetMakefile;
@@ -474,13 +479,13 @@ void buildAll(Bits bits, string branch, bool dmdOnly=false)
 
     info("Building Druntime "~bitsDisplay);
     changeDir(cloneDir~"/druntime");
-    run(makecmd~msvcEnv~makeTargetDruntime);
+    run(makecmd~pic~msvcEnv~makeTargetDruntime);
     removeFiles(cloneDir~"/druntime", "*{"~obj~"}", SpanMode.depth,
         file => !file.baseName.startsWith("gcstub", "minit"));
 
     info("Building Phobos "~bitsDisplay);
     changeDir(cloneDir~"/phobos");
-    run(makecmd~msvcEnv);
+    run(makecmd~pic~msvcEnv);
 
     version(OSX) if(bits == Bits.bits64)
     {

--- a/linux/dmd_deb.sh
+++ b/linux/dmd_deb.sh
@@ -331,7 +331,7 @@ else
 	DFLAGS=-I/usr/include/dmd/phobos -I/usr/include/dmd/druntime/import -L-L/usr/lib/i386-linux-gnu -L--export-dynamic
 
 	[Environment64]
-	DFLAGS=-I/usr/include/dmd/phobos -I/usr/include/dmd/druntime/import -L-L/usr/lib/x86_64-linux-gnu -L--export-dynamic
+	DFLAGS=-I/usr/include/dmd/phobos -I/usr/include/dmd/druntime/import -L-L/usr/lib/x86_64-linux-gnu -L--export-dynamic -fPIC
 	' | sed 's/^\t//' > etc/dmd.conf
 
 

--- a/linux/dmd_rpm.sh
+++ b/linux/dmd_rpm.sh
@@ -252,7 +252,7 @@ do
 		then
 			echo -en '
 			[Environment64]
-			DFLAGS=-I/usr/include/dmd/phobos -I/usr/include/dmd/druntime/import -L-L/usr/lib64 -L--export-dynamic
+			DFLAGS=-I/usr/include/dmd/phobos -I/usr/include/dmd/druntime/import -L-L/usr/lib64 -L--export-dynamic -fPIC
 			' | sed 's/^\t\t\t//' >> etc/dmd.conf
 		fi
 


### PR DESCRIPTION
- build amd64 linux libraries with PIC (no significant overhead of RIP relative
  addressing)
- add -fPIC to default args on amd64