### PR TITLE
Update libcurl-7.52.1

### DIFF
--- a/create_dmd_release/build_all.d
+++ b/create_dmd_release/build_all.d
@@ -448,7 +448,7 @@ int main(string[] args)
 
     enum optlink = "optlink.zip";
     enum libC = "snn.lib";
-    enum libCurl = "libcurl-7.51.0-WinSSL-zlib-x86-x64.zip";
+    enum libCurl = "libcurl-7.52.1-WinSSL-zlib-x86-x64.zip";
 
     auto oldCompilers = platforms
         .map!(p => "dmd.%1$s.%2$s.%3$s".format(oldVer, p, p.os == OS.windows ? "7z" : "tar.xz"));


### PR DESCRIPTION
http://d.darktech.org/libcurl-7.52.1-WinSSL-zlib-x86-x64.zip
MD5: f20bc70736626519eca55c70c3453d8c

Please upload it to http://downloads.dlang.org/other/
