### PR TITLE
preserve latest status in prompt

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -609,8 +609,7 @@ set -gx DMD $dmd
 set -gx DC $dc
 functions -c fish_prompt _old_d_fish_prompt
 function fish_prompt
-    printf '($1)'
-    _old_d_fish_prompt
+    printf '($1)%s' (_old_d_fish_prompt)
 end
 EOF
 }


### PR DESCRIPTION
- running printf before calling the old prompt function did overwrite
  the latest command status, use printf 'new prompt %s' (old_prompt)
  to fix evaluation order