### PR TITLE
Check for dub

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -654,7 +654,7 @@ set -g _OLD_D_LIBRARY_PATH \$LIBRARY_PATH
 set -g _OLD_D_LD_LIBRARY_PATH \$LD_LIBRARY_PATH
 set -g _OLD_D_PS1 \$PS1
 
-set -gx PATH ${DUB_BIN_PATH:+'}${DUB_BIN_PATH}${DUB_BIN_PATH:+' }'$ROOT/$1/$binpath' \$PATH
+set -gx PATH ${DUB_BIN_PATH:+\'}${DUB_BIN_PATH}${DUB_BIN_PATH:+\' }'$ROOT/$1/$binpath' \$PATH
 set -gx LIBRARY_PATH '$ROOT/$1/$libpath' \$LIBRARY_PATH
 set -gx LD_LIBRARY_PATH '$ROOT/$1/$libpath' \$LD_LIBRARY_PATH
 set -gx DMD $dmd

--- a/script/install.sh
+++ b/script/install.sh
@@ -622,9 +622,9 @@ _OLD_D_LIBRARY_PATH="\${LIBRARY_PATH:-}"
 _OLD_D_LD_LIBRARY_PATH="\${LD_LIBRARY_PATH:-}"
 _OLD_D_PS1="\${PS1:-}"
 
-export PATH="${DUB_BIN_PATH}:$ROOT/$1/$binpath:\${PATH:-}"
-export LIBRARY_PATH="$ROOT/$1/$libpath:\${LIBRARY_PATH:-}"
-export LD_LIBRARY_PATH="$ROOT/$1/$libpath:\${LD_LIBRARY_PATH:-}"
+export PATH="${DUB_BIN_PATH}${DUB_BIN_PATH:+:}$ROOT/$1/$binpath\${PATH:+:}\${PATH:-}"
+export LIBRARY_PATH="$ROOT/$1/$libpath\${LIBRARY_PATH:+:}\${LIBRARY_PATH:-}"
+export LD_LIBRARY_PATH="$ROOT/$1/$libpath\${LD_LIBRARY_PATH:+:}\${LD_LIBRARY_PATH:-}"
 export DMD=$dmd
 export DC=$dc
 export PS1="($1)\${PS1:-}"
@@ -654,9 +654,9 @@ set -g _OLD_D_LIBRARY_PATH \$LIBRARY_PATH
 set -g _OLD_D_LD_LIBRARY_PATH \$LD_LIBRARY_PATH
 set -g _OLD_D_PS1 \$PS1
 
-set -gx PATH "${DUB_BIN_PATH}" "$ROOT/$1/$binpath" \$PATH
-set -gx LIBRARY_PATH "$ROOT/$1/$libpath" \$LIBRARY_PATH
-set -gx LD_LIBRARY_PATH "$ROOT/$1/$libpath" \$LD_LIBRARY_PATH
+set -gx PATH ${DUB_BIN_PATH:+'}${DUB_BIN_PATH}${DUB_BIN_PATH:+' }'$ROOT/$1/$binpath' \$PATH
+set -gx LIBRARY_PATH '$ROOT/$1/$libpath' \$LIBRARY_PATH
+set -gx LD_LIBRARY_PATH '$ROOT/$1/$libpath' \$LD_LIBRARY_PATH
 set -gx DMD $dmd
 set -gx DC $dc
 functions -c fish_prompt _old_d_fish_prompt

--- a/script/install.sh
+++ b/script/install.sh
@@ -327,8 +327,11 @@ run_command() {
 
             local -r binpath=$(binpath_for_compiler "$2")
             if [ -f "$ROOT/$2/$binpath/dub" ]; then
-                local -r dub_version=$("$ROOT/$2/$binpath/dub" --version | cut -f3 -d' ' | tr -d ,)
-                log "dub ${dub_version} already installed";
+                if [[ $("$ROOT/$2/$binpath/dub" --version) =~ ([0-9]+\.[0-9]+\.[0-9]+(-[^, ]+)?) ]]; then
+                    log "Using dub ${BASH_REMATCH[1]} shipped with $2"
+                else
+                    log "Using dub shipped with $2"
+                fi
             else
                 DUB_BIN_PATH="${ROOT}/dub"
                 install_dub

--- a/travis.sh
+++ b/travis.sh
@@ -5,6 +5,7 @@ set -uexo pipefail
 compilers=(
     dmd-2.069.2
     dmd-2.071.2
+    dmd-2.077.1
     dmd-2016-10-19
     dmd-master-2016-10-24
     ldc-1.4.0
@@ -13,6 +14,7 @@ compilers=(
 versions=(
     'DMD64 D Compiler v2.069.2'
     'DMD64 D Compiler v2.071.2'
+    'DMD64 D Compiler v2.077.1'
     'DMD64 D Compiler v2.073.0-master-878b882'
     'DMD64 D Compiler v2.073.0-master-ab9d712'
     'LDC - the LLVM D compiler (1.4.0):'
@@ -45,7 +47,9 @@ do
 
     source $(./script/install.sh $compiler --activate)
     deactivate
+
     source $(./script/install.sh $compiler -a)
+    command -v dub >/dev/null 2>&1 || { echo >&2 "DUB hasn't been installed."; exit 1; }
     deactivate
 
     ./script/install.sh uninstall $compiler


### PR DESCRIPTION
> Also seems to fail, at least during initial installation, due to return 1 and set -e (errexit).

Can't reproduce this. Added tests for it to let Travis verify this.

> Mmh, this still queries code.dlang.org when a compiler is already installed.

Added a check. My main motivation was really just to avoid unnecessary downloads on Travis 

>> You also didn't adopt the activate scripts to work w/o a separate dub installation.
> It still "worked", because of the $PATH variable.

Now the `dub` folders shouldn't been written to the `activate` scripts anymore.

> I'll revert this for now to not impact any usage.

Sorry about that :/