### PR TITLE
bump Visual D version to 0.44.2

### DIFF
--- a/windows/d2-installer.nsi
+++ b/windows/d2-installer.nsi
@@ -39,7 +39,7 @@
 ; Routinely Update
 ; ----------------
 ; Visual D
-!define VersionVisualD "0.3.43"
+!define VersionVisualD "0.44.2"
 
 ; DMC
 !define VersionDMC "857"


### PR DESCRIPTION
Would be nice to have the latest version of Visual D in the upcoming installer.