### PR TITLE
fix patch for tools repo

### DIFF
--- a/create_dmd_release/patches/tools.patch
+++ b/create_dmd_release/patches/tools.patch
@@ -1,15 +1,15 @@
 diff --git a/win32.mak b/win32.mak
-index 21aa383..9c398a6 100644
+index ffbbf6d..a1da1d1 100644
 --- a/win32.mak
 +++ b/win32.mak
 @@ -54,8 +54,8 @@ dustmite:  $(ROOT)\dustmite.exe
  
  ALL_OF_PHOBOS_DRUNTIME_AND_DLANG_ORG = # ???
  
--$(DOC)\d.tag : $(ALL_OF_PHOBOS_DRUNTIME_AND_DLANG_ORG)
--	cmd /C "cd $(DOC) && $(MAKE) -f win32.mak d.tag"
-+#$(DOC)\d.tag : $(ALL_OF_PHOBOS_DRUNTIME_AND_DLANG_ORG)
-+#	cmd /C "cd $(DOC) && $(MAKE) -f win32.mak d.tag"
+-$(DOC)\d-tags.json : $(ALL_OF_PHOBOS_DRUNTIME_AND_DLANG_ORG)
+-	cmd /C "cd $(DOC) && $(MAKE) -f win32.mak d-tags.json"
++#$(DOC)\d-tags.json : $(ALL_OF_PHOBOS_DRUNTIME_AND_DLANG_ORG)
++#	cmd /C "cd $(DOC) && $(MAKE) -f win32.mak d-tags.json"
  
- $(ROOT)\dman.exe : dman.d $(DOC)\d.tag
+ $(ROOT)\dman.exe : dman.d $(DOC)\d-tags.json
  	$(DMD) $(DFLAGS) -of$@ dman.d -J$(DOC)


### PR DESCRIPTION
- disables building of docs/d-tags.json prerequistite for dman on WIn
- release docs are only built on Linux and copied to all other OSes
- timestamps should work but are somewhat unreliable (granularity)