### PR TITLE
fix Issue 17805 - -dirty flag on dmd's version

### DIFF
--- a/create_dmd_release/build_all.d
+++ b/create_dmd_release/build_all.d
@@ -491,7 +491,9 @@ int main(string[] args)
     }
     else
     {
-        std.file.write(dmdVersion, gitTag);
+        immutable dmdVer = std.file.readText(dmdVersion).stripRight;
+        enforce(dmdVer == gitTag,
+                "Mismatch between dmd/VERSION: '"~dmdVer~"' and git tag: '"~gitTag~"'.");
     }
     applyPatches(gitTag, skipDocs, workDir~"/clones");
     prepareExtraBins(workDir);


### PR DESCRIPTION
- stop overwriting dmd's VERSION file for release building
  and instead verify that it matches the gitTag
- -dirty flag of git describe was caused by
  newline mismatch in VERSION file