### PR TITLE
Update gdc download path

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -460,7 +460,7 @@ install_compiler() {
             x86_64) local triplet=x86_64-linux-gnu;;
             x86) local triplet=i686-linux-gnu;;
         esac
-        if [[ $ver > "4.8.2" ]]; then
+        if [[ $ver > "5.2.0" ]]; then
             local url="http://gdcproject.org/downloads/binaries/$ver/$triplet/$name.tar.xz"
         else
             local url="http://gdcproject.org/downloads/binaries/$triplet/$name.tar.xz"

--- a/script/install.sh
+++ b/script/install.sh
@@ -460,7 +460,11 @@ install_compiler() {
             x86_64) local triplet=x86_64-linux-gnu;;
             x86) local triplet=i686-linux-gnu;;
         esac
-        local url="http://gdcproject.org/downloads/binaries/$ver/$triplet/$name.tar.xz"
+        if [[ $ver > "4.8.2" ]]; then
+            local url="http://gdcproject.org/downloads/binaries/$ver/$triplet/$name.tar.xz"
+        else
+            local url="http://gdcproject.org/downloads/binaries/$triplet/$name.tar.xz"
+        fi
 
         download_and_unpack "$url" "$path/$1"
 

--- a/script/install.sh
+++ b/script/install.sh
@@ -450,8 +450,9 @@ install_compiler() {
         download_and_unpack "$url" "$path/$1"
 
     # gdc-4.8.2, gdc-4.9.0-alpha1, gdc-5.2, or gdc-5.2-alpha1
-    elif [[ $1 =~ ^gdc-([0-9]+\.[0-9]+(\.[0-9]+)?(-.*)?)$ ]]; then
+    elif [[ $1 =~ ^gdc-(([0-9]+\.[0-9]+(\.[0-9]+)?)([-+].*)?)$ ]]; then
         local name=${BASH_REMATCH[0]}
+        local ver=${BASH_REMATCH[2]}
         if [ $os != linux ]; then
             fatal "no gdc binaries available for $os"
         fi
@@ -459,7 +460,7 @@ install_compiler() {
             x86_64) local triplet=x86_64-linux-gnu;;
             x86) local triplet=i686-linux-gnu;;
         esac
-        local url="http://gdcproject.org/downloads/binaries/$triplet/$name.tar.xz"
+        local url="http://gdcproject.org/downloads/binaries/$ver/$triplet/$name.tar.xz"
 
         download_and_unpack "$url" "$path/$1"
 

--- a/travis.sh
+++ b/travis.sh
@@ -9,6 +9,7 @@ declare -A compilers=(
  ["dmd-master-2016-10-24"]="DMD64 D Compiler v2.073.0-master-ab9d712"
  ["ldc-1.0.0"]="LDC - the LLVM D compiler (1.0.0):"
  ["gdc-4.9.3"]="gdc (crosstool-NG crosstool-ng-1.20.0-232-gc746732 - 20150825-2.066.1-58ec4c13ec) 4.9.3"
+ ["gdc-6.3.0+2.068.2"]="gdc (gdcproject.org 20161225-v2.068.2_gcc6) 6.3.0"
 )
 
 for compiler in "${!compilers[@]}"


### PR DESCRIPTION
example version: gdc6.3.0+2.068.2 -> http://gdcproject.org/downloads/binaries/6.3.0/x86_64-linux-gnu/gdc-6.3.0+2.068.2.tar.xz