### PR TITLE
fix 6625 - update OMF import libraries

### DIFF
--- a/create_dmd_release/build_all.d
+++ b/create_dmd_release/build_all.d
@@ -456,6 +456,7 @@ int main(string[] args)
     enum optlink = "optlink.zip";
     enum libC = "snn.lib";
     enum libCurl = "libcurl-7.52.1-WinSSL-zlib-x86-x64.zip";
+    enum omflibs = "omflibs-winsdk-10.0.16299.15.zip";
 
     auto oldCompilers = platforms
         .map!(p => "dmd.%1$s.%2$s.%3$s".format(oldVer, p, p.os == OS.windows ? "7z" : "tar.xz"));
@@ -465,6 +466,7 @@ int main(string[] args)
     fetchFile("http://ftp.digitalmars.com/"~optlink, cacheDir~"/"~optlink);
     fetchFile("http://ftp.digitalmars.com/"~libC, cacheDir~"/"~libC);
     fetchFile("http://downloads.dlang.org/other/"~libCurl, cacheDir~"/"~libCurl, true);
+    fetchFile("http://downloads.dlang.org/other/"~omflibs, cacheDir~"/"~omflibs, true);
 
     // Unpack previous dmd release
     foreach (platform, oldCompiler; platforms.zip(oldCompilers))
@@ -480,6 +482,8 @@ int main(string[] args)
         copyFile(cacheDir~"/"~libC, workDir~"/windows/old-dmd/dmd2/windows/lib/"~libC);
         // Get libcurl for windows
         extract(cacheDir~"/"~libCurl, workDir~"/windows/old-dmd/");
+        // Get updated OMF import libraries
+        extract(cacheDir~"/"~omflibs, workDir~"/windows/old-dmd/dmd2/windows/lib/");
     }
 
     cloneSources(gitTag, dubTag, isBranch, skipDocs, workDir~"/clones");


### PR DESCRIPTION
- an update_libs.bat script to regenerate omf import libs from a
  Windows SDK is contained in the .zip archive and will be shipped
  as dmd2/windows/lib/update_libs.bat as well

update_libs.bat
```bat
if -%1-==-- echo Missing Windows SDK folder argument & exit /b

:: CTL3D32 is missing in Windows SDK
:: Uuid is a static library in Windows SDK
for %%l in (COMCTL32.LIB CTL3D32.LIB ODBC32.LIB OLEAUT32.LIB WS2_32.LIB advapi32.lib comdlg32.lib gdi32.lib glu32.lib kernel32.lib ole32.lib opengl32.lib rpcrt4.lib shell32.lib user32.lib uuid.lib version.lib wininet.lib winmm.lib winspool.lib wsock32.lib) do coffimplib %1\%%l %%l
```

As the script comment says, CTL3D32.DLL is no longer present and Uuid.lib is now a static library, so those 2 remain in their current state.

Also see [COFFIMPLIB - Digital Mars](http://www.digitalmars.com/ctg/coffimplib.html)