### PR TITLE
create dmd "light" installer on windows

### DIFF
--- a/create_dmd_release/build_all.d
+++ b/create_dmd_release/build_all.d
@@ -485,6 +485,9 @@ int main(string[] args)
         extract(cacheDir~"/"~libCurl, workDir~"/windows/old-dmd/");
         // Get updated OMF import libraries
         extract(cacheDir~"/"~omflibs, workDir~"/windows/old-dmd/dmd2/windows/lib/");
+
+        // grab mingw sources
+        run("git clone --depth 1 --branch 5.0-active https://git.code.sf.net/p/mingw/mingw-org-wsl.git " ~ workDir ~ "/clones/mingw");
     }
 
     cloneSources(gitTag, dubTag, isBranch, skipDocs, workDir~"/clones");

--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -573,11 +573,11 @@ void createRelease(string branch)
     if(exists(allExtrasDir)) copyDir(allExtrasDir, releaseDir);
     if(exists( osExtrasDir)) copyDir( osExtrasDir, releaseDir);
 
-    // Copy sources (should cppunit be omitted??)
+    // Copy sources
     copyDirVersioned(cloneDir~"/dmd/src",  releaseDir~"/dmd2/src/dmd");
-    copyDirVersioned(cloneDir~"/dmd/ini",  releaseDir~"/dmd2");
     copyDirVersioned(cloneDir~"/druntime", releaseDir~"/dmd2/src/druntime");
     copyDirVersioned(cloneDir~"/phobos",   releaseDir~"/dmd2/src/phobos");
+    copyDirVersioned(cloneDir~"/dmd/ini/" ~ osDirName,  releaseDir~"/dmd2/" ~ osDirName);
 
     // druntime/doc doesn't get generated on Windows with --only-64, I don't know why.
     if(exists(cloneDir~"/druntime/doc"))

--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -546,6 +546,18 @@ void buildAll(Bits bits, string branch, bool dmdOnly=false)
 
         removeFiles(cloneDir~"/tools", "*.{"~obj~"}", SpanMode.depth);
 
+        version(Windows)
+        {
+            if(do64Bit)
+            {
+                changeDir(cloneDir~"/tools/winsdk");
+                string w32api_lib = "../../mingw/w32api/lib";
+                string msvcrt_def_in = "../../mingw/mingwrt/msvcrt-xref/msvcrt.def.in";
+                run("%VCDIR%\\vcvarsall x64 && "~hostDMD~" -run buildsdk.d x64 "~w32api_lib~" lib64 "~msvcrt_def_in);
+                run("%VCDIR%\\vcvarsall x86 && "~hostDMD~" -run buildsdk.d x86 "~w32api_lib~" lib32mscoff "~msvcrt_def_in);
+            }
+        }
+
         // build dub with stable (host) compiler, b/c it breaks
         // too easily with the latest compiler, e.g. for nightlies
         info("Building Dub "~bitsDisplay);
@@ -631,6 +643,9 @@ void createRelease(string branch)
             copyFile(cloneDir~"/phobos/phobos64.lib", osDir~"/lib64/phobos64.lib");
             copyFile(cloneDir~"/druntime/lib/gcstub32mscoff.obj", osDir~"/lib32mscoff/gcstub32mscoff.obj");
             copyFile(cloneDir~"/phobos/phobos32mscoff.lib", osDir~"/lib32mscoff/phobos32mscoff.lib");
+
+            copyDir(cloneDir~"/tools/winsdk/lib64", osDir~"/lib64/sdk");
+            copyDir(cloneDir~"/tools/winsdk/lib32mscoff", osDir~"/lib32mscoff/sdk");
         }
     }
     else

--- a/create_dmd_release/extras/windows/dmd2/windows/bin/sc-light.ini
+++ b/create_dmd_release/extras/windows/dmd2/windows/bin/sc-light.ini
@@ -1,0 +1,34 @@
+[Version]
+version=7.51 Build 020
+
+; environment for both 32/64 bit
+[Environment]
+DFLAGS="-I%@P%\..\..\src\phobos" "-I%@P%\..\..\src\druntime\import"
+
+; optlink only reads from the Environment section so we need this redundancy
+; from the Environment32 section (bugzilla 11302)
+LIB=%@P%\..\lib
+
+[Environment32]
+LIB=%@P%\..\lib
+LINKCMD=%@P%\link.exe
+
+
+[Environment64]
+LIB=%@P%\..\lib64;%@P%\..\lib64\sdk
+
+; needed to avoid COMDAT folding (bugzilla 10664)
+DFLAGS=%DFLAGS% -L/OPT:NOICF -mscrtlib=msvcrt100
+
+; default to 32-bit linker (can generate 64-bit code) that has a common path
+; for VS2008, VS2010, VS2012, and VS2013. This will be overridden below if the
+; installer detects VS.
+LINKCMD=%@P%\lld-link.exe
+
+; -----------------------------------------------------------------------------
+[Environment32mscoff]
+LIB=%@P%\..\lib32mscoff;%@P%\..\lib32mscoff\sdk
+
+; needed to avoid COMDAT folding (bugzilla 10664)
+DFLAGS=%DFLAGS% -L/OPT:NOICF -mscrtlib=msvcrt100
+LINKCMD=%@P%\lld-link.exe

--- a/windows/d2-installer-descriptions.nsh
+++ b/windows/d2-installer-descriptions.nsh
@@ -4,12 +4,15 @@
 
 ; Sections
 LangString DESC_Dmd2Files ${LANG_ENGLISH} "Digital Mars D version 2 compiler"
+LangString DESC_SMShortcuts ${LANG_ENGLISH} "Add Shortcuts to the Start Menu to start the command interpreter with adjusted environment"
 LangString DESC_AddD2ToPath ${LANG_ENGLISH} "Modify the PATH environment variable so DMD can be used from any command prompt"
 
 LangString DESC_VisualDDownload ${LANG_ENGLISH} "Visual Studio package providing both project management and language services. It works with Visual Studio 2008-2017 (and the free VS Shells)"
 LangString DESC_DmcDownload ${LANG_ENGLISH} "Digital Mars C/C++ compiler"
 LangString DESC_Dmd1Download ${LANG_ENGLISH} "Digital Mars D version 1 compiler (discontinued)"
 
+LangString DESC_VCRedistx86 ${LANG_ENGLISH} "Microsoft Visual C++ 2010 x86 Redistributable (only selectable if not installed)"
+LangString DESC_VCRedistx64 ${LANG_ENGLISH} "Microsoft Visual C++ 2010 x64 Redistributable (only selectable if not installed)"
 
 
 ; Shortcuts
@@ -21,8 +24,14 @@ LangString SHORTCUT_Uninstall ${LANG_ENGLISH} "Uninstall"
 
 !insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN
     !insertmacro MUI_DESCRIPTION_TEXT ${Dmd2Files} $(DESC_Dmd2Files)
+    !insertmacro MUI_DESCRIPTION_TEXT ${StartMenuShortcuts} $(DESC_SMShortcuts)
     !insertmacro MUI_DESCRIPTION_TEXT ${AddD2ToPath} $(DESC_AddD2ToPath)
+!ifdef Light
+    !insertmacro MUI_DESCRIPTION_TEXT ${VCRedistributable86} $(DESC_VCRedistx86)
+    !insertmacro MUI_DESCRIPTION_TEXT ${VCRedistributable64} $(DESC_VCRedistx64)
+!else
     !insertmacro MUI_DESCRIPTION_TEXT ${VisualDDownload} $(DESC_VisualDDownload)
     !insertmacro MUI_DESCRIPTION_TEXT ${DmcDownload} $(DESC_DmcDownload)
     !insertmacro MUI_DESCRIPTION_TEXT ${Dmd1Download} $(DESC_Dmd1Download)
+!endif
 !insertmacro MUI_FUNCTION_DESCRIPTION_END

--- a/windows/d2-installer.nsi
+++ b/windows/d2-installer.nsi
@@ -267,8 +267,10 @@ SectionGroup /e "D2"
   !ifdef Light
     SetOutPath $INSTDIR\dmd2
     File /r ${EmbedD2Dir}\windows
+    File    ${EmbedD2Dir}\license.txt
     SetOutPath $INSTDIR\dmd2\src\druntime
     File /r ${EmbedD2Dir}\src\druntime\import
+    File    ${EmbedD2Dir}\src\druntime\license.txt
     SetOutPath $INSTDIR\dmd2\src
     File /r ${EmbedD2Dir}\src\phobos
     SetOutPath $INSTDIR\dmd2\windows\bin

--- a/windows/makefile
+++ b/windows/makefile
@@ -9,6 +9,11 @@ NSIS="\program files (x86)\nsis\makensis"
 dmd-$(V2).exe : dinstaller.nsi dinstaller_descriptions.nsh EnvVarUpdate.nsh makefile
 	$(NSIS) /DVersion1=$(V1) /DVersion2=$(V2) dinstaller.nsi
 
+dmd-light-$(V2).exe : d2-installer.nsi d2-installer-descriptions.nsh EnvVarUpdate.nsh makefile
+	$(NSIS) /DLight /DVersion2=$(V2) d2-installer.nsi
+
+light: dmd-light-$(V2).exe
+
 clean :
 	del dmd-$(V2).exe
 


### PR DESCRIPTION
- grabs mingw from it's repository
- builds import libraries from mingw definition files
- builds stub for msvcr100.dll
- creates installer using these sdk libraries and lld-link

I couldn't test build_all though because it only runs on linux.

I'm also a bit confused about the use of the create_dmd_release_extra folder: it seems they do not end up in the result directory/zip. Instead link.exe is expected create_dmd_release\extras\dmd2\windows\bin, not in the additional extras. So what's the point of the committed extra folders?

This depends on https://github.com/dlang/tools/pull/267
The dmd/phobos sources should have https://github.com/dlang/dmd/pull/7261 and https://github.com/dlang/phobos/pull/5839 applied.