### PR TITLE
Attempt to make windows installer more silent when /S is given

### DIFF
--- a/windows/d2-installer.nsi
+++ b/windows/d2-installer.nsi
@@ -144,7 +144,7 @@ SetCompressor /SOLID lzma
   System::Call 'kernel32::CreateMutexA(i 0, i 0, t "digital_mars_d_compiler_installer") ?e'
   Pop $R0
   StrCmp $R0 0 +3
-    MessageBox /SD IDOK MB_OK|MB_ICONSTOP "An instance of DMD installer is already running"
+    MessageBox MB_OK|MB_ICONSTOP "An instance of DMD installer is already running" /SD IDOK
     Abort
 !macroend
 
@@ -160,7 +160,7 @@ SetCompressor /SOLID lzma
   !endif
 
   ; failed
-  MessageBox MB_OK|MB_ICONEXCLAMATION "Could not download ${Filename}$\r$\n$\r$\n${Url}"
+  MessageBox MB_OK|MB_ICONEXCLAMATION "Could not download ${Filename}$\r$\n$\r$\n${Url}" /SD IDOK
 
   Goto dandr_done
 
@@ -282,7 +282,7 @@ SectionGroup /e "D2"
     StrCmp $VCVer "" no_vc_detected write_vc_path
 
     no_vc_detected:
-      MessageBox MB_OK "Could not detect Visual Studio (2008-2017 are supported). No 64-bit support."
+      MessageBox MB_OK "Could not detect Visual Studio (2008-2017 are supported). No 64-bit support." /SD IDOK
       goto finish_vc_path
 
     write_vc_path:
@@ -295,7 +295,7 @@ SectionGroup /e "D2"
     StrCmp $WinSDKPath "" no_sdk_detected write_sdk_path
 
     no_sdk_detected:
-      MessageBox MB_OK "Could not detect Windows SDK (6.0A-10.0 are supported). No 64-bit support."
+      MessageBox MB_OK "Could not detect Windows SDK (6.0A-10.0 are supported). No 64-bit support." /SD IDOK
       goto finish_sdk_path
 
     write_sdk_path:
@@ -461,12 +461,13 @@ Function .onInit
   ; Exit if uninstaller return an error
   IfErrors 0 +3
     MessageBox MB_OK|MB_ICONSTOP \
-    "An error occurred when removing DMD$\n$\nRun '${InstallerFilename} /f' to force install ${DName} ${Version2}"
+    "An error occurred when removing DMD$\n$\nRun '${InstallerFilename} /f' to force install ${DName} ${Version2}" \
+    /SD IDOK
     Abort
   ; Remove in background the remaining uninstaller program itself
   Sleep 1000
   Exec '$R5 /S'
-  ; MessageBox MB_OK|MB_ICONINFORMATION "Previous DMD uninstalled"
+  ; MessageBox MB_OK|MB_ICONINFORMATION "Previous DMD uninstalled" /SD IDOK
 
   done_uninst_prev:
   ; End of removing previous dmd installation section
@@ -492,7 +493,8 @@ Function .onInit
     ; Exit if uninstaller return an error
     IfErrors 0 +3
       MessageBox MB_OK|MB_ICONSTOP \
-      "An error occurred when removing $I v$J$\n$\nRun '${InstallerFilename} /f' to force install ${DName} ${Version2}"
+      "An error occurred when removing $I v$J$\n$\nRun '${InstallerFilename} /f' to force install ${DName} ${Version2}" \
+      /SD IDOK
       Abort
     ; Exit if uninstaller is cancelled by user
     StrCmp $K 0 +2

--- a/windows/d2-installer.nsi
+++ b/windows/d2-installer.nsi
@@ -144,7 +144,7 @@ SetCompressor /SOLID lzma
   System::Call 'kernel32::CreateMutexA(i 0, i 0, t "digital_mars_d_compiler_installer") ?e'
   Pop $R0
   StrCmp $R0 0 +3
-    MessageBox MB_OK|MB_ICONSTOP "An instance of DMD installer is already running"
+    MessageBox /SD IDOK MB_OK|MB_ICONSTOP "An instance of DMD installer is already running"
     Abort
 !macroend
 
@@ -453,7 +453,7 @@ Function .onInit
   StrCmp $R5 "" done_uninst_prev
   MessageBox MB_OKCANCEL|MB_ICONQUESTION \
   "A previous DMD is installed on your system$\n$\nPress 'OK' to replace by ${DName} ${Version2}" \
-  IDOK +2
+  /SD IDOK IDOK +2
   Abort
   ClearErrors
   ; Run uninstaller fron installed directory
@@ -480,7 +480,7 @@ Function .onInit
   ReadRegStr $J HKLM "${ARP}" "DisplayVersion"
   MessageBox MB_OKCANCEL|MB_ICONQUESTION \
   "$I v$J is installed on your system$\n$\nPress 'OK' to replace by ${DName} ${Version2}" \
-  IDOK uninst
+  /SD IDOK IDOK uninst
   Abort
 
   uninst:
@@ -510,7 +510,7 @@ Function .onInit
   ask_vs:
     MessageBox MB_YESNO|MB_ICONQUESTION \
     "For 64-bit support MSVC and the Windows SDK are needed but no compatible versions were found. Do you want to install VS2013?" \
-    IDYES install_vs IDNO done_vs
+    /SD IDNO IDYES install_vs IDNO done_vs
 
   install_vs:
     !insertmacro DownloadAndRun ${VS2013Filename} ${VS2013Url} ""


### PR DESCRIPTION
This PR attempts to silence the installer when the /S option is passed. The installer opens messages boxes in certain circumstances. Most of them are just informative and do not actually require user intervention. For example, one of them occurs when no VS is installed and asks whether it should automatically install VS2013.

This obviously prevents fully automated and unattended installations of dmd using this installer. I've stumbled upon this because I'm currently setting up such a scenario and tried using that installer on a fresh Window install.

I have to say, however, that I was not able to build and test the installer myself because I didn't find documentation on how to set it up or even how to begin... So I'm kind of providing this change "blindly". I'd be glad to test the installer manually if I had some form of instructions on how to create it.

(I tried the bat file in the bootstrapper dir with the argument `v2.077.0` but it fails halfway through with a compile errors in `src\object.d`...)
