### PR TITLE
Use a fallback mirror for code.dlang.org

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -763,19 +763,25 @@ install_dub() {
         log "no dub binaries available for $OS"
         return
     fi
-    local url=http://code.dlang.org/download/LATEST
-    logV "Determining latest dub version ($url)."
-    dub="dub-$(fetch $url)"
+    local latestMirrors=(
+        "http://code.dlang.org/download/LATEST"
+        "http://dlang.github.io/dub/LATEST"
+    )
+    logV "Determining latest dub version (${latestMirrors[0]})."
+    dubVersion="$(fetch "${latestMirrors[@]}")"
+    dub="dub-${dubVersion}"
     if [ -d "$ROOT/$dub" ]; then
         log "$dub already installed"
         return
     fi
     local tmp url
     tmp=$(mkdtemp)
-    url="http://code.dlang.org/files/$dub-$OS-$ARCH.tar.gz"
-
-    log "Downloading and unpacking $url"
-    download_without_verify "$tmp/dub.tar.gz" "$url"
+    local mirrors=(
+        "http://code.dlang.org/files/$dub-$OS-$ARCH.tar.gz"
+        "https://github.com/dlang/dub/releases/download/${dubVersion}/$dub-$OS-$ARCH.tar.gz"
+    )
+    log "Downloading and unpacking ${mirrors[0]}"
+    download_without_verify "$tmp/dub.tar.gz" "${mirrors[@]}"
     tar -C "$tmp" -zxf "$tmp/dub.tar.gz"
     logV "Removing old dub versions"
     rm -rf "$ROOT/dub" "$ROOT/dub-*"


### PR DESCRIPTION
As https://github.com/dlang/installer/pull/218 doesn't seem to be moving forward, I have uploaded all DUB releases to GitHub, which should be much more reliable (see https://github.com/dlang/dub/issues/1290 for details).
At the moment, there isn't a mirror for `code.dlang.org/download/LATEST` (we should probably create a gh-pages repo like LDC or use an S3 bucket), so for now I simply used the GitHub API. I know that it's rate-limited, but imho having a chance to succeed is a lot better than having none.

If code.dlang.org is down, we still manage to get the latest DUB:

```
dmd-2.077.1 already installed
curl: (7) Failed to connect to code.dlang.org port 80: Connection refused
curl: (7) Failed to connect to code.dlang.org port 80: Connection refused
curl: (7) Failed to connect to code.dlang.org port 80: Connection refused
curl: (7) Failed to connect to code.dlang.org port 80: Connection refused
curl: (7) Failed to connect to code.dlang.org port 80: Connection refused
Failed to download 'http://code.dlang.org/download/LATEST'
Downloading and unpacking http://code.dlang.org/files/dub-1.6.0-linux-x86_64.tar.gz

curl: (7) Failed to connect to code.dlang.org port 80: Connection refused
Downloading and unpacking https://github.com/dlang/dub/releases/download/v1.6.0/dub-1.6.0-linux-x86_64.tar.gz
######################################################################## 100.0%

Run `source ~/dlang/dmd-2.077.1/activate` in your shell to use dmd-2.077.1.
This will setup PATH, LIBRARY_PATH, LD_LIBRARY_PATH, DMD, DC, and PS1.
Run `deactivate` later on to restore your environment.
```