### PR TITLE
Parse a configuration file

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -91,3 +91,19 @@ git checkout -- script/install.sh
 if [ "${TRAVIS_OS_NAME:-}" != "osx" ]; then
     shellcheck script/install.sh
 fi
+
+# Test user config
+mkdir -p ~/.config/dlang
+echo "ROOT=~/.dlang" > ~/.config/dlang/installer.cfg
+./script/install.sh dmd
+has_user_installed_dmd=0
+for file in ~/.dlang/dmd* ; do
+    if [ -e "$file" ] ; then
+        has_user_installed_dmd=1
+        break
+    fi
+done
+if [ ${has_user_installed_dmd} -eq 0 ] ; then
+    echo "Failed to install DMD in the user-specified directory."
+fi
+rm -rf ~/.dlang ~/.config


### PR DESCRIPTION
I really like the installer, but I would prefer if it would use a different directory by default.
This PR allows the installer script to read a configuration file and thus have permanent configuration settings. I know that I could write a small wrapper around the installer or simply patch it, but I believe that I am not the only one having this problem.

tl;dr: With this PR, one can define `~/.config/dlang/installer.cfg` and do sth. like:

```
ROOT=~/.dlang
```

To use a different default directory.