### PR TITLE
[WIP] Add AppVeyor build script

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 image:
 - Visual Studio 2015
-- Visual Studio 2017
+#- Visual Studio 2017
 platform: x64
 environment:
  matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,62 @@
+image:
+- Visual Studio 2015
+- Visual Studio 2017
+platform: x64
+environment:
+ matrix:
+  - DC: dmd
+    DVersion: nightly
+    arch: x64
+  #- DC: dmd
+    #DVersion: nightly
+    #arch: x86
+  #- DC: dmd
+    #DVersion: beta
+    #arch: x64
+  #- DC: dmd
+    #DVersion: beta
+    #arch: x86
+  #- DC: dmd
+    #DVersion: stable
+    #arch: x64
+  #- DC: dmd
+    #DVersion: stable
+    #arch: x86
+  #- DC: dmd
+    #DVersion: 2.077.1
+    #arch: x64
+  #- DC: dmd
+    #DVersion: 2.077.1
+    #arch: x86
+  #- DC: ldc
+    #DVersion: beta
+    #arch: x86
+  #- DC: ldc
+    #DVersion: beta
+    #arch: x64
+  #- DC: ldc
+    #DVersion: stable
+    #arch: x86
+  #- DC: ldc
+    #DVersion: stable
+    #arch: x64
+  #- DC: ldc
+    #DVersion: 1.6.0
+    #arch: x86
+  #- DC: ldc
+    #DVersion: 1.6.0
+    #arch: x64
+
+skip_tags: false
+build_script:
+ - ps: script\install.ps1
+ - if "%APPVEYOR_BUILD_WORKER_IMAGE:~-4%" == "2017" call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" -arch=%compilersetupargs%
+ - if "%APPVEYOR_BUILD_WORKER_IMAGE:~-4%" == "2015" call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %compilersetupargs%
+
+test_script:
+ - echo %PLATFORM%
+ - echo %Darch%
+ - echo %DC%
+ - echo %PATH%
+ - '%DC% --version'
+ - dub --root=test\minimal_dub --arch=%Darch% --compiler=%DC%

--- a/script/install.ps1
+++ b/script/install.ps1
@@ -1,0 +1,74 @@
+# Build script for automatically setting up dmd & ldc on AppVeyor
+function ResolveLatestDMD
+{
+    $version = $env:DVersion;
+    if($version -eq "stable") {
+        $latest = (Invoke-WebRequest "http://downloads.dlang.org/releases/LATEST").toString();
+        $url = "http://downloads.dlang.org/releases/2.x/$($latest)/dmd.$($latest).windows.7z";
+    }elseif($version -eq "beta") {
+        $latest = (Invoke-WebRequest "http://downloads.dlang.org/pre-releases/LATEST").toString();
+        $latestVersion = $latest.split("-")[0].split("~")[0];
+        $url = "http://downloads.dlang.org/pre-releases/2.x/$($latestVersion)/dmd.$($latest).windows.7z";
+    }elseif($version -eq "nightly") {
+        $latest = (Invoke-WebRequest "https://nightlies.dlang.org/dmd-nightly/LATEST").toString().replace("`n","").replace("`r","");
+        $url = "https://nightlies.dlang.org/dmd-$($latest)/dmd.master.windows.7z"
+    }else {
+        $url = "http://downloads.dlang.org/releases/2.x/$($version)/dmd.$($version).windows.7z";
+    }
+    $env:PATH += ";C:\dmd2\windows\bin;";
+    return $url;
+}
+function ResolveLatestLDC
+{
+    $version = $env:DVersion;
+    if($version -eq "stable") {
+        $latest = (Invoke-WebRequest "https://ldc-developers.github.io/LATEST").toString().replace("`n","").replace("`r","");
+        $url = "https://github.com/ldc-developers/ldc/releases/download/v$($latest)/ldc2-$($latest)-win64-msvc.zip";
+    }elseif($version -eq "beta") {
+        $latest = (Invoke-WebRequest "https://ldc-developers.github.io/LATEST_BETA").toString().replace("`n","").replace("`r","");
+        $url = "https://github.com/ldc-developers/ldc/releases/download/v$($latest)/ldc2-$($latest)-win64-msvc.zip";
+    } else {
+        $latest = $version;
+        $url = "https://github.com/ldc-developers/ldc/releases/download/v$($version)/ldc2-$($version)-win64-msvc.zip";
+    }
+    $env:PATH += ";C:\ldc2-$($latest)-win64-msvc\bin";
+    $env:DC = "ldc2";
+    return $url;
+}
+function SetUpDCompiler
+{
+    $env:toolchain = "msvc";
+    if($env:DC -eq "dmd"){
+      echo "downloading ...";
+      $url = ResolveLatestDMD;
+      echo $url;
+      Invoke-WebRequest $url -OutFile "c:\dmd.7z";
+      echo "finished.";
+      pushd c:\\;
+      7z x dmd.7z > $null;
+      popd;
+    }
+    elseif($env:DC -eq "ldc"){
+      echo "downloading ...";
+      $url = ResolveLatestLDC;
+      echo $url;
+      Invoke-WebRequest $url -OutFile "c:\ldc.zip";
+      echo "finished.";
+      pushd c:\\;
+      7z x ldc.zip > $null;
+      popd;
+    }
+}
+SetUpDCompiler
+
+if($env:arch -eq "x86"){
+    $env:compilersetupargs = "x86";
+    $env:Darch = "x86";
+    $env:DConf = "m32";
+}elseif($env:arch -eq "x64"){
+    $env:compilersetupargs = "amd64";
+    $env:Darch = "x86_64";
+    $env:DConf = "m64";
+}
+# This needs to be done more generically (currently only works on AppVeyor)
+$env:compilersetup = "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall";

--- a/test/minimal_dub/.gitignore
+++ b/test/minimal_dub/.gitignore
@@ -1,0 +1,14 @@
+.dub
+docs.json
+__dummy.html
+docs/
+installer.so
+installer.dylib
+installer.dll
+installer.a
+installer.lib
+installer-test-*
+*.exe
+*.o
+*.obj
+*.lst

--- a/test/minimal_dub/dub.sdl
+++ b/test/minimal_dub/dub.sdl
@@ -1,0 +1,5 @@
+name "installer"
+description "D install scripts"
+authors "D Language Foundation"
+copyright "Copyright © 2017, D Language Foundation"
+license "BSD-1.0"

--- a/test/minimal_dub/source/app.d
+++ b/test/minimal_dub/source/app.d
@@ -1,0 +1,6 @@
+import std.stdio;
+
+void main()
+{
+	writeln("Hello World");
+}


### PR DESCRIPTION
Copy-pasting this script around, isn't very feasible.
The idea is to do sth. like this for now:

```yml
build_script:
- ps: wget http://dlang.org/install.ps -OutFile install.ps1
- ps: .\install.ps1
```

(we can always look into getting native AppVeyor support later)

This is far from ready, but I just configured AppVeyor for this repo, s.t. I can directly test this without needing a Windows machine.