### PR TITLE
Windows installer: install mingw libs and improve VS selection

### DIFF
--- a/create_dmd_release/build_all.d
+++ b/create_dmd_release/build_all.d
@@ -230,8 +230,32 @@ void prepareExtraBins(string workDir)
         "windbg.hlp", "ddemangle.exe", "lib.exe", "link.exe", "make.exe",
         "replace.exe", "shell.exe", "windbg.exe", "dm.dll", "eecxxx86.dll",
         "emx86.dll", "mspdb41.dll", "shcv.dll", "tlloc.dll", "libcurl.dll",
+        "lld-link.exe",
     ].addPrefix("bin/");
     auto winBins64 = ["libcurl.dll"].addPrefix("bin64/");
+    auto mingwCoffLibs = [
+        "aclui.lib", "advapi32.lib", "avicap32.lib", "avifil32.lib", "bthprops.lib",
+        "cap.lib", "comctl32.lib", "comdlg32.lib", "crypt32.lib", "ctl3d32.lib",
+        "d3d8.lib", "d3d9.lib", "d3dim.lib", "d3drm.lib", "d3dx8d.lib", "d3dx9d.lib",
+        "d3dxof.lib", "ddraw.lib", "dhcpcsvc.lib", "dinput8.lib", "dinput.lib", "dlcapi.lib",
+        "dnsapi.lib", "dplayx.lib", "dpnaddr.lib", "dpnet.lib", "dpnlobby.lib", "dpvoice.lib",
+        "dsetup.lib", "dsound.lib", "faultrep.lib", "gdi32.lib", "gdiplus.lib", "glaux.lib",
+        "glu32.lib", "icmui.lib", "igmpagnt.lib", "imagehlp.lib", "imm32.lib", "iphlpapi.lib",
+        "kernel32.lib", "ksproxy.lib", "ksuser.lib", "lz32.lib", "mapi32.lib", "mfcuia32.lib",
+        "mgmtapi.lib", "mprapi.lib", "mpr.lib", "mqrt.lib", "msacm32.lib", "mscms.lib",
+        "msdmo.lib", "msimg32.lib", "msvcp60.lib", "msvcrt100.lib", "msvfw32.lib",
+        "mswsock.lib", "nddeapi.lib", "netapi32.lib", "ntdll.lib", "odbc32.lib",
+        "odbccp32.lib", "oldnames.lib", "ole32.lib", "oleacc.lib", "oleaut32.lib",
+        "olecli32.lib", "oledlg.lib", "olepro32.lib", "olesvr32.lib", "opengl32.lib",
+        "penwin32.lib", "pkpd32.lib", "powrprof.lib", "psapi.lib", "quartz.lib",
+        "rapi.lib", "rasapi32.lib", "rasdlg.lib", "rpcdce4.lib", "rpcns4.lib", "rpcrt4.lib",
+        "rtm.lib", "rtutils.lib", "secur32.lib", "setupapi.lib", "shell32.lib", "shfolder.lib",
+        "shlwapi.lib", "snmpapi.lib", "svrapi.lib", "tapi32.lib", "thunk32.lib",
+        "url.lib", "user32.lib", "userenv.lib", "usp10.lib", "uuid.lib", "uxtheme.lib",
+        "vdmdbg.lib", "version.lib", "win32spl.lib", "wininet.lib", "winmm.lib",
+        "winspool.lib", "winstrm.lib", "wldap32.lib", "wow32.lib", "ws2_32.lib",
+        "wsnmp32.lib", "wsock32.lib", "wst.lib", "wtsapi32.lib",
+    ];
     auto winLibs = [
         "advapi32.lib", "COMCTL32.LIB", "comdlg32.lib", "CTL3D32.LIB",
         "gdi32.lib", "kernel32.lib", "ODBC32.LIB", "ole32.lib", "OLEAUT32.LIB",
@@ -239,8 +263,9 @@ void prepareExtraBins(string workDir)
         "winmm.lib", "winspool.lib", "WS2_32.LIB", "wsock32.lib", "curl.lib",
         "update_libs.bat",
     ].addPrefix("lib/");
-    auto winLibs64 = ["curl.lib"].addPrefix("lib64/");
-    auto winFiles = chain(winBins, winBins64, winLibs, winLibs64).array();
+    auto winLibs32Coff = (mingwCoffLibs ~ "curl.lib").addPrefix("lib32mscoff/");
+    auto winLibs64 = (mingwCoffLibs ~ "curl.lib").addPrefix("lib64/");
+    auto winFiles = chain(winBins, winBins64, winLibs, winLibs32Coff, winLibs64).array();
 
     auto extraBins = [
         windows_both : winFiles,
@@ -460,6 +485,8 @@ int main(string[] args)
     enum libC = "snn.lib";
     enum libCurl = "libcurl-7.52.1-WinSSL-zlib-x86-x64.zip";
     enum omflibs = "omflibs-winsdk-10.0.16299.15.zip";
+    enum mingwlibs = "mingw-libs-5.0.2.zip";
+    enum lld = "lld-link-5.0.1.zip";
 
     auto oldCompilers = platforms
         .map!(p => "dmd.%1$s.%2$s.%3$s".format(oldVer, p, p.os == OS.windows ? "7z" : "tar.xz"));
@@ -470,6 +497,8 @@ int main(string[] args)
     fetchFile("http://ftp.digitalmars.com/"~libC, cacheDir~"/"~libC);
     fetchFile("http://downloads.dlang.org/other/"~libCurl, cacheDir~"/"~libCurl, true);
     fetchFile("http://downloads.dlang.org/other/"~omflibs, cacheDir~"/"~omflibs, true);
+    fetchFile("http://downloads.dlang.org/other/"~mingwlibs, cacheDir~"/"~mingwlibs, true);
+    fetchFile("http://downloads.dlang.org/other/"~lld, cacheDir~"/"~lld, true);
 
     // Unpack previous dmd release
     foreach (platform, oldCompiler; platforms.zip(oldCompilers))
@@ -487,9 +516,10 @@ int main(string[] args)
         extract(cacheDir~"/"~libCurl, workDir~"/windows/old-dmd/");
         // Get updated OMF import libraries
         extract(cacheDir~"/"~omflibs, workDir~"/windows/old-dmd/dmd2/windows/lib/");
-
-        // grab mingw sources
-        run("git clone --depth 1 --branch 5.0-active https://git.code.sf.net/p/mingw/mingw-org-wsl.git " ~ workDir ~ "/clones/mingw");
+        // Get mingw coff libraries
+        extract(cacheDir~"/"~mingwlibs, workDir~"/windows/old-dmd/");
+        // Get lld-link.exe
+        extract(cacheDir~"/"~lld, workDir~"/windows/old-dmd/dmd2/windows/bin/");
     }
 
     cloneSources(gitTag, dubTag, isBranch, skipDocs, workDir~"/clones");

--- a/create_dmd_release/build_all.d
+++ b/create_dmd_release/build_all.d
@@ -487,6 +487,9 @@ int main(string[] args)
         extract(cacheDir~"/"~libCurl, workDir~"/windows/old-dmd/");
         // Get updated OMF import libraries
         extract(cacheDir~"/"~omflibs, workDir~"/windows/old-dmd/dmd2/windows/lib/");
+
+        // grab mingw sources
+        run("git clone --depth 1 --branch 5.0-active https://git.code.sf.net/p/mingw/mingw-org-wsl.git " ~ workDir ~ "/clones/mingw");
     }
 
     cloneSources(gitTag, dubTag, isBranch, skipDocs, workDir~"/clones");

--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -528,18 +528,6 @@ void buildAll(Bits bits, string branch, bool dmdOnly=false)
 
         removeFiles(cloneDir~"/tools", "*.{"~obj~"}", SpanMode.depth);
 
-        version(Windows)
-        {
-            if(do64Bit)
-            {
-                changeDir(cloneDir~"/tools/winsdk");
-                string w32api_lib = "../../mingw/w32api/lib";
-                string msvcrt_def_in = "../../mingw/mingwrt/msvcrt-xref/msvcrt.def.in";
-                run("%VCDIR%\\vcvarsall x64 && "~hostDMD~" -run buildsdk.d x64 "~w32api_lib~" lib64 "~msvcrt_def_in);
-                run("%VCDIR%\\vcvarsall x86 && "~hostDMD~" -run buildsdk.d x86 "~w32api_lib~" lib32mscoff "~msvcrt_def_in);
-            }
-        }
-
         // build dub with stable (host) compiler, b/c it breaks
         // too easily with the latest compiler, e.g. for nightlies
         info("Building Dub "~bitsDisplay);
@@ -619,9 +607,6 @@ void createRelease(string branch)
         {
             copyFile(cloneDir~"/phobos/phobos64.lib", osDir~"/lib64/phobos64.lib");
             copyFile(cloneDir~"/phobos/phobos32mscoff.lib", osDir~"/lib32mscoff/phobos32mscoff.lib");
-
-            copyDir(cloneDir~"/tools/winsdk/lib64", osDir~"/lib64/mingw");
-            copyDir(cloneDir~"/tools/winsdk/lib32mscoff", osDir~"/lib32mscoff/mingw");
         }
     }
     else

--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -528,6 +528,18 @@ void buildAll(Bits bits, string branch, bool dmdOnly=false)
 
         removeFiles(cloneDir~"/tools", "*.{"~obj~"}", SpanMode.depth);
 
+        version(Windows)
+        {
+            if(do64Bit)
+            {
+                changeDir(cloneDir~"/tools/winsdk");
+                string w32api_lib = "../../mingw/w32api/lib";
+                string msvcrt_def_in = "../../mingw/mingwrt/msvcrt-xref/msvcrt.def.in";
+                run("%VCDIR%\\vcvarsall x64 && "~hostDMD~" -run buildsdk.d x64 "~w32api_lib~" lib64 "~msvcrt_def_in);
+                run("%VCDIR%\\vcvarsall x86 && "~hostDMD~" -run buildsdk.d x86 "~w32api_lib~" lib32mscoff "~msvcrt_def_in);
+            }
+        }
+
         // build dub with stable (host) compiler, b/c it breaks
         // too easily with the latest compiler, e.g. for nightlies
         info("Building Dub "~bitsDisplay);
@@ -607,6 +619,9 @@ void createRelease(string branch)
         {
             copyFile(cloneDir~"/phobos/phobos64.lib", osDir~"/lib64/phobos64.lib");
             copyFile(cloneDir~"/phobos/phobos32mscoff.lib", osDir~"/lib32mscoff/phobos32mscoff.lib");
+
+            copyDir(cloneDir~"/tools/winsdk/lib64", osDir~"/lib64/mingw");
+            copyDir(cloneDir~"/tools/winsdk/lib32mscoff", osDir~"/lib32mscoff/mingw");
         }
     }
     else

--- a/windows/d2-installer-descriptions.nsh
+++ b/windows/d2-installer-descriptions.nsh
@@ -4,12 +4,12 @@
 
 ; Sections
 LangString DESC_Dmd2Files ${LANG_ENGLISH} "Digital Mars D version 2 compiler"
+LangString DESC_SMShortcuts ${LANG_ENGLISH} "Add Shortcuts to the Start Menu to start the command interpreter with adjusted environment"
 LangString DESC_AddD2ToPath ${LANG_ENGLISH} "Modify the PATH environment variable so DMD can be used from any command prompt"
 
 LangString DESC_VisualDDownload ${LANG_ENGLISH} "Visual Studio package providing both project management and language services. It works with Visual Studio 2008-2017 (and the free VS Shells)"
 LangString DESC_DmcDownload ${LANG_ENGLISH} "Digital Mars C/C++ compiler"
 LangString DESC_Dmd1Download ${LANG_ENGLISH} "Digital Mars D version 1 compiler (discontinued)"
-
 
 
 ; Shortcuts
@@ -21,6 +21,7 @@ LangString SHORTCUT_Uninstall ${LANG_ENGLISH} "Uninstall"
 
 !insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN
     !insertmacro MUI_DESCRIPTION_TEXT ${Dmd2Files} $(DESC_Dmd2Files)
+    !insertmacro MUI_DESCRIPTION_TEXT ${StartMenuShortcuts} $(DESC_SMShortcuts)
     !insertmacro MUI_DESCRIPTION_TEXT ${AddD2ToPath} $(DESC_AddD2ToPath)
     !insertmacro MUI_DESCRIPTION_TEXT ${VisualDDownload} $(DESC_VisualDDownload)
     !insertmacro MUI_DESCRIPTION_TEXT ${DmcDownload} $(DESC_DmcDownload)

--- a/windows/makefile
+++ b/windows/makefile
@@ -6,7 +6,7 @@ V2=$(\cbx\VERSION)
 #NSIS="\program files\nsis\makensis"
 NSIS="\program files (x86)\nsis\makensis"
 
-dmd-$(V2).exe : dinstaller.nsi dinstaller_descriptions.nsh EnvVarUpdate.nsh makefile
+dmd-$(V2).exe : d2-installer.nsi d2-installer_descriptions.nsh EnvVarUpdate.nsh makefile
 	$(NSIS) /DVersion1=$(V1) /DVersion2=$(V2) dinstaller.nsi
 
 clean :

--- a/windows/vcinstall.ini
+++ b/windows/vcinstall.ini
@@ -1,0 +1,64 @@
+[Settings]
+NumFields=7
+
+[Field 1]
+Type=Groupbox
+Text=Select Install Type
+Flags=NOTABSTOP
+Left=0
+Right=300
+Top=36
+Bottom=136
+
+[Field 2]
+Type=RadioButton
+Text=Download and install Visual Studio 2013
+State=0
+Left=20
+Right=300
+Top=48
+Bottom=60
+
+[Field 3]
+Type=RadioButton
+Text=Download and install Visual Studio 2017
+State=1
+Left=20
+Right=300
+Top=64
+Bottom=76
+
+[Field 4]
+Type=RadioButton
+Text=Download and install Build Tools for Visual Studio 2017
+State=0
+Left=20
+Right=300
+Top=80
+Bottom=94
+
+[Field 5]
+Type=RadioButton
+Text=Install VC2010 redistributables to use it with MinGW Platform libraries
+State=0
+Left=20
+Right=300
+Top=98
+Bottom=112
+
+[Field 6]
+Type=RadioButton
+Text=Do nothing (you can manually install any of the options above later)
+State=0
+Left=20
+Right=300
+Top=116
+Bottom=130
+
+[Field 7]
+Type=Label
+Text=No Visual Studio Installation was found on your system. To build 64-bit programs or 32-bit programs targeting the VC runtime, you need to install one of the options below.
+Left=0
+Right=300
+Top=0
+Bottom=36


### PR DESCRIPTION
- add mingw libraries to installation
- add installer page to select VS installation
- no need to patch sc.ini as dmd detects VS

@MartinNowak You will still have to add lld-link.exe to the extra folders.

The additional page only appears if no VS installation is detected and looks like this:

![dinstaller](https://user-images.githubusercontent.com/702284/34327190-43d00376-e8be-11e7-92fc-95a3167daa82.png)
