### PR TITLE
Add 'ldc-nightly' install target

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -205,7 +205,8 @@ command_help() {
   dmd|gdc|ldc           latest version of a compiler
   dmd|gdc|ldc-<version> specific version of a compiler (e.g. dmd-2.071.1, ldc-1.1.0-beta2)
   dmd|ldc-beta          latest beta version of a compiler
-  dmd|ldc-nightly       latest nightly version of a compiler
+  dmd-nightly           latest dmd nightly
+  ldc-latest-ci         latest ldc CI build (with assertions enabled)
   dmd-2016-08-08        specific dmd nightly
 '
 
@@ -474,15 +475,15 @@ resolve_latest() {
             logV "Determining latest ldc-beta version ($url)."
             COMPILER="ldc-$(fetch $url)"
             ;;
-        ldc-nightly)
+        ldc-latest-ci)
             local url=http://thecybershadow.net/d/github-ldc
-            logV "Finding latest ldc-nightly binary package (at $url)."
+            logV "Finding latest ldc CI binary package (at $url)."
             local package
             package="$(fetch $url)"
             if [[ $package =~ ldc2-([0-9a-f]*)-$OS-$ARCH. ]]; then
                 COMPILER="ldc-${BASH_REMATCH[1]}"
             else
-                fatal "Could not find ldc-nightly binaries (OS: $OS, arch: $ARCH)"
+                fatal "Could not find ldc CI binaries (OS: $OS, arch: $ARCH)"
             fi
             ;;
         gdc)
@@ -550,7 +551,7 @@ install_compiler() {
 
         download_and_unpack_without_verify "$ROOT/$compiler" "$url"
 
-    # ldc-nightly: ldc-8c0abd52-20171222
+    # ldc-latest-ci: ldc-8c0abd52
     elif [[ $1 =~ ^ldc-([0-9a-f]+) ]]; then
         local package_hash=${BASH_REMATCH[1]}
         local url="https://github.com/ldc-developers/ldc/releases/download/CI/ldc2-$package_hash-$OS-$ARCH.tar.xz"

--- a/script/install.sh
+++ b/script/install.sh
@@ -475,11 +475,11 @@ resolve_latest() {
             COMPILER="ldc-$(fetch $url)"
             ;;
         ldc-nightly)
-            local ci_url=https://github.com/ldc-developers/ldc/releases/tag/CI
-            logV "Finding latest ldc-nightly binary package (at $ci_url)."
+            local url=http://thecybershadow.net/d/github-ldc
+            logV "Finding latest ldc-nightly binary package (at $url)."
             local package
-            package="$(fetch $ci_url | grep -o "ldc2-[0-9a-f]*-$OS-$ARCH-[0-9]*.tar.xz" | head -n 1)"
-            if [[ $package =~ ^ldc2-([0-9a-f]*)-$OS-$ARCH-([0-9]*)\.tar\.xz$ ]]; then
+            package="$(fetch $url)"
+            if [[ $package =~ ^([0-9a-f]*)[[:space:]]([0-9]*)$ ]]; then
                 COMPILER="ldc-${BASH_REMATCH[1]}-${BASH_REMATCH[2]}"
             else
                 fatal "Could not find ldc-nightly binaries (OS: $OS, arch: $ARCH)"
@@ -557,7 +557,7 @@ install_compiler() {
         local url="https://github.com/ldc-developers/ldc/releases/download/CI/ldc2-$package_hash-$OS-$ARCH-$package_date.tar.xz"
 
         # Install into 'ldc-8c0abd52-20171222' directory.
-        download_and_unpack "$url" "$ROOT/$1"
+        download_and_unpack_without_verify "$ROOT/$compiler" "$url"
 
     # gdc-4.8.2, gdc-4.9.0-alpha1, gdc-5.2, or gdc-5.2-alpha1
     elif [[ $1 =~ ^gdc-([0-9]+\.[0-9]+(\.[0-9]+)?(-.*)?)$ ]]; then

--- a/script/install.sh
+++ b/script/install.sh
@@ -479,8 +479,8 @@ resolve_latest() {
             logV "Finding latest ldc-nightly binary package (at $url)."
             local package
             package="$(fetch $url)"
-            if [[ $package =~ ^([0-9a-f]*)[[:space:]]([0-9]*)$ ]]; then
-                COMPILER="ldc-${BASH_REMATCH[1]}-${BASH_REMATCH[2]}"
+            if [[ $package =~ ldc2-([0-9a-f]*)-$OS-$ARCH. ]]; then
+                COMPILER="ldc-${BASH_REMATCH[1]}"
             else
                 fatal "Could not find ldc-nightly binaries (OS: $OS, arch: $ARCH)"
             fi
@@ -551,10 +551,9 @@ install_compiler() {
         download_and_unpack_without_verify "$ROOT/$compiler" "$url"
 
     # ldc-nightly: ldc-8c0abd52-20171222
-    elif [[ $1 =~ ^ldc-([0-9a-f]+)-([0-9]+) ]]; then
+    elif [[ $1 =~ ^ldc-([0-9a-f]+) ]]; then
         local package_hash=${BASH_REMATCH[1]}
-        local package_date=${BASH_REMATCH[2]}
-        local url="https://github.com/ldc-developers/ldc/releases/download/CI/ldc2-$package_hash-$OS-$ARCH-$package_date.tar.xz"
+        local url="https://github.com/ldc-developers/ldc/releases/download/CI/ldc2-$package_hash-$OS-$ARCH.tar.xz"
 
         # Install into 'ldc-8c0abd52-20171222' directory.
         download_and_unpack_without_verify "$ROOT/$compiler" "$url"

--- a/travis.sh
+++ b/travis.sh
@@ -79,7 +79,7 @@ do
 done
 
 # test resolution of latest using the remove error message
-latest=(dmd dmd-beta dmd-master dmd-nightly ldc ldc-beta gdc dmd-2018-10-14)
+latest=(dmd dmd-beta dmd-master dmd-nightly ldc ldc-beta ldc-nightly gdc dmd-2018-10-14)
 for compiler in "${latest[@]}"
 do
     set +e

--- a/travis.sh
+++ b/travis.sh
@@ -79,7 +79,7 @@ do
 done
 
 # test resolution of latest using the remove error message
-latest=(dmd dmd-beta dmd-master dmd-nightly ldc ldc-beta ldc-nightly gdc dmd-2018-10-14)
+latest=(dmd dmd-beta dmd-master dmd-nightly ldc ldc-beta ldc-latest-ci gdc dmd-2018-10-14)
 for compiler in "${latest[@]}"
 do
     set +e


### PR DESCRIPTION
This PR installs ldc-nightly in e.g. "ldc-8c0abd52-20171222"
(DMD installs nightlies in e.g. "dmd-master-2017-12-27")

LDC does not have a LATEST_NIGHTLY file online, so I opted for just downloading the nightlies release page and grepping for what the binary package name should look like.

Tested on OSX.

