### PR TITLE
Add '--dmd' and '--dc' to print the path of the installed compiler

### DIFF
--- a/changelog/install-dmd-dc.dd
+++ b/changelog/install-dmd-dc.dd
@@ -1,0 +1,39 @@
+Installation script now supports `get-path <compiler>`
+
+`get-path <compiler>` has been added as a new action to the install script.
+This action allows printing information about a compiler binary.
+The behavior of `get-path` can be changed with the following additional options:
+
+$(UL
+    $(LI `--install` install compiler if not found locally)
+    $(LI `--dmd` returns the path of a specific compiler executable (DMD-alike interface))
+    $(LI `--dub` returns the path of the DUB executable)
+)
+
+$(H4 Examples)
+
+$(CONSOLE curl https://dlang.org/install.sh | bash -s get-path --install
+/home/user/dlang/dmd-2.093.0/linux/bin64/dmd
+)
+
+$(CONSOLE ~/dlang/install.sh get-path ldc-1.23.0 --install
+/home/user/dlang/ldc-1.23.0/bin/ldc2
+)
+
+$(CONSOLE ~/dlang/install.sh get-path --dmd ldc --install
+/home/user/dlang/ldc-1.23.0/bin/ldmd2
+)
+
+$(CONSOLE ~/dlang/install.sh get-path --dub ldc --install
+/home/user/dlang/ldc-1.23.0/bin/dub
+)
+
+$(CONSOLE ~/dlang/install.sh get-path --dub dub-1.22.0 --install
+/home/user/dlang/dub-1.22.0/dub
+)
+
+$(CONSOLE ~/dlang/install.sh get-path --dub ldc,dub-1.22.0 --install
+/home/user/dlang/dub-1.22.0/dub
+)
+
+If a compiler installation isn't found and `--install` has not been passed, an error will be issued.

--- a/script/install.sh
+++ b/script/install.sh
@@ -172,6 +172,8 @@ display_path() {
 COMMAND=
 COMPILER=dmd
 VERBOSITY=1
+GET_PATH_AUTO_INSTALL=0
+GET_PATH_COMPILER=dc
 # Set a default install path depending on the POSIX/Windows environment.
 if posix_terminal; then
     ROOT=~/dlang
@@ -236,6 +238,7 @@ Commands
   uninstall     Remove an installed D compiler
   list          List all installed D compilers
   update        Update this dlang script
+  get-path      Path of the installed compiler executable
 
 Options
 
@@ -331,6 +334,36 @@ Description
 
   Update the dlang installer itself and the keyring.
 '
+            ;;
+
+        get-path)
+            log 'Usage
+
+  install.sh get-path <compiler>
+
+Description
+
+  Find the path of an installed D compiler.
+
+Options
+
+  --install         Install the compiler if it is not installed
+  --dmd             Find the DMD-alike interface instead
+  --dub             Find the DUB instance
+
+Examples
+
+  install.sh
+  install.sh get-path dmd
+  install.sh get-path dmd-2.093.0 --install
+  install.sh get-path --dmd ldc-1.19.0
+  install.sh get-path --dub ldc-1.19.0
+  install.sh get-path ldc-1.19.0 --install
+  install.sh get-path --dub dub-1.21.0
+'
+            log "$_compiler"
+            ;;
+
     esac
 }
 
@@ -338,7 +371,9 @@ Description
 
 parse_args() {
     local _help=
-    local _activate=
+    local _installAction=
+    local _getPathAction=
+    local _autoInstallFlag=
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -359,10 +394,35 @@ parse_args() {
                 ;;
 
             -a | --activate)
-                _activate=1
+                if [ -n "$_installAction" ]; then
+                    fatal "$1 conflicts with --${_installAction}"
+                fi
+                _installAction="activate"
+                ;;
+
+            --dmd)
+                if [ -n "$_getPathAction" ]; then
+                    fatal "$1 conflicts with --${_getPathAction}"
+                fi
+                _getPathAction="dmd"
+                ;;
+
+            --dub)
+                if [ -n "$_getPathAction" ]; then
+                    fatal "$1 conflicts with --${_getPathAction}"
+                fi
+                _getPathAction="dub"
+                ;;
+
+            --install)
+                _autoInstallFlag=1
                 ;;
 
             use | install | uninstall | list | update)
+                COMMAND=$1
+                ;;
+
+            get-path)
                 COMMAND=$1
                 ;;
 
@@ -390,14 +450,41 @@ parse_args() {
         command_help $COMMAND
         exit 0
     fi
-    if [ -n "$_activate" ]; then
-       if [ "${COMMAND:-install}" == "install" ]; then
-           VERBOSITY=0
-       else
-           command_help $COMMAND
-           exit 1
-       fi
+    local command_="${COMMAND:-install}"
+    if [ -n "$_installAction" ] ; then
+        if [ "$command_" == "install" ]; then
+            VERBOSITY=0
+        else
+            logE "ERROR: --activate is not allowed for ${command_}."
+            command_help $COMMAND
+            exit 1
+        fi
     fi
+    if [ -n "$_autoInstallFlag" ] ; then
+        if [ "$command_" == "get-path" ]; then
+            GET_PATH_AUTO_INSTALL=1
+        else
+            logE "ERROR: --install is not allowed for ${command_}."
+            command_help $COMMAND
+            exit 1
+        fi
+    fi
+    if [ -n "$_getPathAction" ] ; then
+        if [ "$command_" == "get-path" ]; then
+            case "$_getPathAction" in
+                dmd|dub)
+                    GET_PATH_COMPILER=$_getPathAction
+                    ;;
+                *)
+                    fatal "Internal Error. Invalid get-path: $_getPathAction"
+            esac
+        else
+            logE "ERROR: --${_getPathAction} is not allowed for ${command_}."
+            command_help $COMMAND
+            exit 1
+        fi
+    fi
+
     IFS="," read -r _compiler _dub <<< "$COMPILER"
     if [ -n "${_dub:-}" ] ; then
         COMPILER="$_compiler"
@@ -411,51 +498,7 @@ parse_args() {
 run_command() {
     case $1 in
         install)
-            check_tools curl
-            if [ ! -f "$ROOT/install.sh" ] || [ ! -f "$ROOT/d-keyring.gpg" ] ; then
-                install_dlang_installer
-            fi
-            if [ -z "${2:-}" ]; then
-                fatal "Missing compiler argument for $1 command.";
-            fi
-            if [ -d "$ROOT/$2" ]; then
-                log "$2 already installed";
-            else
-                install_compiler "$2"
-            fi
-
-            # Only try to install dub if it wasn't the main compiler
-            if ! [[ $COMPILER =~ ^dub ]] ; then
-                if [ -n "${DUB:-}" ] ; then
-                    # A dub version was explicitly specified with ,dub-1.8.0
-                    DUB_BIN_PATH="${ROOT}/${DUB}"
-                    # Check whether the latest dub version needs to be resolved
-                    if ! [[ $DUB =~ ^dub- ]] ; then
-                        resolve_latest "$DUB"
-                        install_dub "dub-$DUB_VERSION"
-                    else
-                        install_dub "$DUB"
-                    fi
-                else
-                    # compiler was installed without requesting dub
-                    local -r binpath=$(binpath_for_compiler "$2")
-                    if [ -f "$ROOT/$2/$binpath/dub" ]; then
-                        if [[ $("$ROOT/$2/$binpath/dub" --version) =~ ([0-9]+\.[0-9]+\.[0-9]+(-[^, ]+)?) ]]; then
-                            log "Using dub ${BASH_REMATCH[1]} shipped with $2"
-                        else
-                            log "Using dub shipped with $2"
-                        fi
-                    else
-                        # no dub bundled - manually installing
-                        DUB_BIN_PATH="${ROOT}/dub"
-                        resolve_latest dub
-                        install_dub "dub-$DUB_VERSION"
-                    fi
-                fi
-            fi
-
-            write_env_vars "$2"
-
+            install_d "$1" "${2:-}"
             if posix_terminal; then
                 if [ "$(basename "$SHELL")" = fish ]; then
                     local suffix=.fish
@@ -478,6 +521,44 @@ Run \`$(display_path "$ROOT/$2/activate.bat")\` to add $2 to your PATH."
             fi
             ;;
 
+        get-path)
+            if [ $GET_PATH_AUTO_INSTALL -eq 0 ] ; then
+                if [ ! -d "$ROOT/$2" ]; then
+                    fatal "Requested $2 is not installed. Install or rerun with --install.";
+                fi
+                if [ "$GET_PATH_COMPILER" == "dub" ] ; then
+                    local dubBinPath
+                    dubBinPath="$(binexec_for_dub_compiler "$2")"
+                    if [ ! -f "$dubBinPath" ] ; then
+                        fatal "Requested DUB is not installed. Install or rerun with --install.";
+                    fi
+                fi
+            fi
+            previousVerbosity=$VERBOSITY
+            VERBOSITY=-1
+            install_d "$1" "${2:-}"
+            VERBOSITY=$previousVerbosity
+            case "$GET_PATH_COMPILER" in
+                dmd)
+                    if [[ $COMPILER =~ ^dub ]] ; then
+                        fatal "ERROR: DUB is not a compiler."
+                    fi
+                    echo "$ROOT/$2/$(binexec_for_dmd_compiler "$2")"
+                    ;;
+                dc)
+                    if [[ $COMPILER =~ ^dub ]] ; then
+                        fatal "ERROR: DUB is not a compiler."
+                    fi
+                    echo "$ROOT/$2/$(binexec_for_dc_compiler "$2")"
+                    ;;
+                dub)
+                    binexec_for_dub_compiler "$2"
+                    ;;
+                *)
+                fatal "Unknown value for GET_PATH_COMPILER encountered."
+            esac
+            ;;
+
         uninstall)
             if [ -z "${2:-}" ]; then
                 fatal "Missing compiler argument for $1 command.";
@@ -493,6 +574,55 @@ Run \`$(display_path "$ROOT/$2/activate.bat")\` to add $2 to your PATH."
             install_dlang_installer
             ;;
     esac
+}
+
+install_d() {
+    local commandName="$1"
+    if [ -z "${2:-}" ]; then
+        fatal "Missing compiler argument for $commandName command.";
+    fi
+    local compilerName="$2"
+    check_tools curl
+    if [ ! -f "$ROOT/install.sh" ] || [ ! -f "$ROOT/d-keyring.gpg" ] ; then
+        install_dlang_installer
+    fi
+    if [ -d "$ROOT/$compilerName" ]; then
+        log "$compilerName already installed";
+    else
+        install_compiler "$compilerName"
+    fi
+
+    # Only try to install dub if it wasn't the main compiler
+    if ! [[ $COMPILER =~ ^dub ]] ; then
+        if [ -n "${DUB:-}" ] ; then
+            # A dub version was explicitly specified with ,dub-1.8.0
+            DUB_BIN_PATH="${ROOT}/${DUB}"
+            # Check whether the latest dub version needs to be resolved
+            if ! [[ $DUB =~ ^dub- ]] ; then
+                resolve_latest "$DUB"
+                install_dub "dub-$DUB_VERSION"
+            else
+                install_dub "$DUB"
+            fi
+        else
+            # compiler was installed without requesting dub
+            local -r binpath=$(binpath_for_compiler "$compilerName")
+            if [ -f "$ROOT/$2/$binpath/dub" ]; then
+                if [[ $("$ROOT/$2/$binpath/dub" --version) =~ ([0-9]+\.[0-9]+\.[0-9]+(-[^, ]+)?) ]]; then
+                    log "Using dub ${BASH_REMATCH[1]} shipped with $compilerName"
+                else
+                    log "Using dub shipped with $compilerName"
+                fi
+            else
+                # no dub bundled - manually installing
+                DUB_BIN_PATH="${ROOT}/dub"
+                resolve_latest dub
+                install_dub "dub-$DUB_VERSION"
+            fi
+        fi
+    fi
+
+    write_env_vars "$compilerName"
 }
 
 install_dlang_installer() {
@@ -848,6 +978,67 @@ binpath_for_compiler() {
             ;;
     esac
     echo "$binpath"
+}
+
+# Path to the compiler executable with a DMD-compatible interface
+binexec_for_dmd_compiler() {
+    local binPath
+    binPath=$(binpath_for_compiler "$1")/
+    case $1 in
+        dmd*)
+            binPath+=dmd
+            ;;
+        ldc*)
+            binPath+=ldmd2
+            ;;
+        gdc*)
+            binPath+=gdmd
+            ;;
+    esac
+    echo "$binPath"
+}
+
+# Path to the compiler executable with its custom interface
+binexec_for_dc_compiler() {
+    local binPath
+    binPath=$(binpath_for_compiler "$1")/
+    case $1 in
+        dmd*)
+            binPath+=dmd
+            ;;
+        ldc*)
+            binPath+=ldc2
+            ;;
+        gdc*)
+            binPath+=gdc
+            ;;
+    esac
+    echo "$binPath"
+}
+
+binexec_for_dub_compiler() {
+    local dub binPath
+    dub="${DUB:-}"
+    if [[ "$dub" =~ ^dub- ]] ; then
+        binPath="$ROOT/$DUB/dub"
+    elif [ "$dub" == "dub" ] ; then
+        binPath="$ROOT/$DUB/dub"
+    else
+        binPath="$ROOT/$1/$(binpath_for_compiler "$1")"
+        case $1 in
+            dub*)
+                binPath+=dub
+                ;;
+            dmd*|ldc*|gdc*)
+                binPath+=/dub
+                ;;
+        esac
+        # check for old compiler which ship without dub
+        if [ ! -f "$binPath" ]; then
+            binPath="$ROOT/dub/dub"
+        fi
+    fi
+    echo "$binPath"
 }
 
 write_env_vars() {

--- a/test/common.sh
+++ b/test/common.sh
@@ -4,3 +4,19 @@ set -eu -o pipefail
 
 ROOT="$DIR/../"
 INSTALLER="$ROOT/script/install.sh"
+
+assert() {
+    actual="$1"
+    expected="$2"
+    if [ "$actual" != "$expected" ] ; then
+        echo "Actual: $actual"
+        echo "Expected: $expected"
+        exit 1
+    fi
+}
+
+err_report() {
+    echo "Error on line $1"
+}
+
+trap 'err_report $LINENO' ERR

--- a/test/t/where.sh
+++ b/test/t/where.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+
+set -eux -o pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/../
+. $DIR/common.sh
+
+OS_NAME="${TRAVIS_OS_NAME:-linux}"
+
+compilers=(
+    dmd-2.078.2
+    dmd-master-2020-03-10
+    ldc-1.7.0
+    dmd-2.078.2,dub-1.21.0
+)
+ROOT="$HOME/dlang"
+versions_dmd=()
+versions_dc=()
+versions_dub=()
+
+if [ "${OS_NAME}" == "linux" ] ; then
+    # No GDC binaries on OSX
+    compilers+=(
+        "gdc-4.8.5"
+    )
+    versions_dmd+=(
+        "$ROOT/dmd-2.078.2/linux/bin64/dmd"
+        "$ROOT/dmd-master-2020-03-10/linux/bin64/dmd"
+        "$ROOT/ldc-1.7.0/bin/ldmd2"
+        "$ROOT/dmd-2.078.2/linux/bin64/dmd"
+        "$ROOT/gdc-4.8.5/bin/gdmd"
+    )
+    versions_dc+=(
+        "$ROOT/dmd-2.078.2/linux/bin64/dmd"
+        "$ROOT/dmd-master-2020-03-10/linux/bin64/dmd"
+        "$ROOT/ldc-1.7.0/bin/ldc2"
+        "$ROOT/dmd-2.078.2/linux/bin64/dmd"
+        "$ROOT/gdc-4.8.5/bin/gdc"
+    )
+    versions_dub+=(
+        "$ROOT/dmd-2.078.2/linux/bin64/dub"
+        "$ROOT/dmd-master-2020-03-10/linux/bin64/dub"
+        "$ROOT/ldc-1.7.0/bin/dub"
+        "$ROOT/dub-1.21.0/dub"
+        "$ROOT/dub/dub"
+    )
+elif [ "${OS_NAME}" == "osx" ]; then
+    versions_dmd+=(
+        "$ROOT/dmd-2.078.2/osx/bin/dmd"
+        "$ROOT/dmd-master-2020-03-10/osx/bin/dmd"
+        "$ROOT/ldc-1.7.0/bin/ldmd2"
+        "$ROOT/dmd-2.078.2/osx/bin/dmd"
+    )
+    versions_dc+=(
+        "$ROOT/dmd-2.078.2/osx/bin/dmd"
+        "$ROOT/dmd-master-2020-03-10/osx/bin/dmd"
+        "$ROOT/ldc-1.7.0/bin/ldc2"
+        "$ROOT/dmd-2.078.2/osx/bin/dmd"
+    )
+    versions_dub+=(
+        "$ROOT/dmd-2.078.2/osx/bin/dub"
+        "$ROOT/dmd-master-2020-03-10/osx/bin/dub"
+        "$ROOT/ldc-1.7.0/bin/dub"
+        "$ROOT/dub-1.21.0/dub"
+    )
+elif [ "${OS_NAME}" == "windows" ]; then
+    versions_dmd+=(
+        "$ROOT/dmd-2.078.2/windows/bin/dmd"
+        "$ROOT/dmd-master-2020-03-10/windows/bin/dmd"
+        "$ROOT/ldc-1.7.0/bin/ldmd2"
+        "$ROOT/dmd-2.078.2/windows/bin/dmd"
+    )
+    versions_dc+=(
+        "$ROOT/dmd-2.078.2/windows/bin/dmd"
+        "$ROOT/dmd-master-2020-03-10/windows/bin/dmd"
+        "$ROOT/ldc-1.7.0/bin/ldc2"
+        "$ROOT/dmd-2.078.2/windows/bin/dmd"
+    )
+    versions_dub+=(
+        "$ROOT/dmd-2.078.2/windows/bin/dub"
+        "$ROOT/dmd-master-2020-03-10/windows/bin/dub"
+        "$ROOT/ldc-1.7.0/bin/dub"
+        "$ROOT/dub-1.21.0/dub"
+    )
+else
+    echo "Unknown platform: ${OS_NAME}"
+    exit 1
+fi
+
+for idx in "${!compilers[@]}"
+do
+    compiler="${compilers[$idx]}"
+    echo "Testing: $compiler"
+    assert "$("$INSTALLER" get-path --dmd "$compiler" --install)" "${versions_dmd[$idx]}"
+    assert "$("$INSTALLER" get-path "$compiler" --dmd)" "${versions_dmd[$idx]}"
+    assert "$("$INSTALLER" get-path "$compiler")" "${versions_dc[$idx]}"
+    assert "$("$INSTALLER" get-path --dub "$compiler")" "${versions_dub[$idx]}"
+    $INSTALLER uninstall "$compiler"
+done
+
+# Test for conflicts
+flag_combinations=(
+    "get-path --dmd --dub"
+    "install --dmd"
+    "install --dub"
+    "install --install"
+    "update --dub"
+)
+for flags in "${flag_combinations[@]}" ; do
+    IFS=" " read -r -a flagArray <<< "$flags"
+    out=$(! "$INSTALLER" "${flagArray[@]}" 2>&1)
+    if ! (echo "$out" | grep -q -E "(conflicts|ERROR)") ; then
+        echo "ERROR: $flags was valid"
+        exit 1
+    fi
+done
+
+################################################################################
+# assert error without --install
+################################################################################
+out=$(! "$INSTALLER" get-path dmd-2.077.0 2>&1)
+echo "$out" | grep -q "not installed"
+
+################################################################################
+# check installations without dub
+################################################################################
+
+$INSTALLER install dmd-2.066.0
+rm -rf ~/dlang/dub # manually uninstall dub
+out=$(! "$INSTALLER" get-path --dub dmd-2.066.0 2>&1)
+echo "$out" | grep -q "DUB is not installed"
+$INSTALLER uninstall dmd-2.066.0
+
+################################################################################
+# check dub installation
+################################################################################
+
+# check errors if dub is installed
+$INSTALLER uninstall dub-1.22.0 || echo "dub-1.22.0 wasn't installed"
+out=$(! "$INSTALLER" get-path dub-1.22.0 2>&1)
+echo "$out" | grep -q "not installed"
+
+out=$(! "$INSTALLER" get-path --dmd dub-1.22.0 2>&1)
+echo "$out" | grep -q "not installed"
+
+out=$(! "$INSTALLER" get-path dub-1.22.0 --dub 2>&1)
+echo "$out" | grep -q "not installed"
+
+# dmd is installed, but not dub
+$INSTALLER install dmd-2.079.0
+out=$(! "$INSTALLER" get-path dmd-2.079.0,dub-1.22.0 --dub 2>&1)
+echo "$out" | grep -q "not installed"
+$INSTALLER uninstall dmd-2.079.0
+
+# errors when requesting a compiler with dub
+out=$(! "$INSTALLER" get-path --install dub-1.22.0 2>&1 | tail -n1)
+assert "$out" "ERROR: DUB is not a compiler."
+
+out=$(! "$INSTALLER" get-path --dmd dub-1.22.0 2>&1)
+assert "$out" "ERROR: DUB is not a compiler."
+
+# dub with --dub
+out=$("$INSTALLER" get-path dub-1.22.0 --dub 2>&1)
+assert "$out" "$ROOT/dub-1.22.0/dub"
+
+$INSTALLER uninstall dub-1.22.0


### PR DESCRIPTION
This has come up frequently in the past.

Use case: one has a generic compiler variable like `$DMD` in a CI script and wants to use the install script without activating the environment.

See also:
- https://github.com/dlang/dmd/pull/7848#issuecomment-364235083
- https://github.com/dlang/tools/pull/297/files#diff-f9a62833538ab14fff849c2be16ab986R9

I'm not fully convinced about the name, so bike-shedding is allowed.

An alternative to this would have been to add a flag similar to `-a|--activate`.
That would require a two line change and would be fine for me too.

CC @WebDrake