### PR TITLE
temporarily remove chmgen (d.chm, dman) from release

### DIFF
--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -512,21 +512,8 @@ void buildAll(Bits bits, string branch, bool dmdOnly=false)
             {
                 changeDir(cloneDir~"/dlang.org");
                 run(makecmd~" DOC_OUTPUT_DIR="~origDir~"/docs release");
-                // put into docs/ folder which gets copied to all other platforms
-                copyFile("d-tags-release.json", origDir~"/docs/d-tags-release.json");
                 // copy generated man pages to docs/man which gets copied to all other platforms
                 copyDir(cloneDir~"/dmd/generated/docs/man", origDir~"/docs/man");
-            }
-        }
-        else version (Windows)
-        {
-            if (bits == Bits.bits32)
-            {
-                // copy linux-generated docs into dlang.org
-                copyDir(origDir~"/docs", cloneDir~"/dlang.org");
-                // and build the d.chm file
-                changeDir(cloneDir~"/dlang.org");
-                run(makecmd~" chm");
             }
         }
     }
@@ -538,12 +525,6 @@ void buildAll(Bits bits, string branch, bool dmdOnly=false)
         run(makecmd~" rdmd");
         run(makecmd~" ddemangle");
         run(makecmd~" dustmite");
-        if (!skipDocs)
-        {
-            // use tags built with linux docs
-            copyFile(origDir~"/docs/d-tags-release.json", cloneDir~"/tools/d-tags.json");
-            run(makecmd~" dman");
-        }
 
         removeFiles(cloneDir~"/tools", "*.{"~obj~"}", SpanMode.depth);
 
@@ -595,11 +576,6 @@ void createRelease(string branch)
             ( a.endsWith(".html") || a.startsWith("css/", "images/", "js/") );
         // copy docs from linux build
         copyDir(origDir~"/docs", releaseDir~"/dmd2/html/d", a => dlangFilter(a));
-        version(Windows)
-        {
-            if(do32Bit)
-                copyFile(cloneDir~"/dlang.org/d.chm", releaseBin32Dir~"/d.chm");
-        }
         copyDirVersioned(cloneDir~"/dmd/samples",  releaseDir~"/dmd2/samples/d");
         copyDirVersioned(cloneDir~"/tools/man", releaseDir~"/dmd2/man");
         // copy man pages from linux build

--- a/windows/d2-installer.nsi
+++ b/windows/d2-installer.nsi
@@ -322,7 +322,6 @@ SectionGroup /e "D2"
     CreateDirectory "$SMPROGRAMS\D"
 
     CreateShortCut "$SMPROGRAMS\D\D2 HTML Documentation.lnk" "$INSTDIR\dmd2\html\d\index.html"
-    CreateShortCut "$SMPROGRAMS\D\D2 Documentation.lnk" "$INSTDIR\dmd2\windows\bin\d.chm"
     CreateShortCut "$SMPROGRAMS\D\D2 32-bit Command Prompt.lnk" '%comspec%' '/k ""$INSTDIR\dmd2vars32.bat""' "" "" SW_SHOWNORMAL "" "Open D2 32-bit Command Prompt"
     CreateShortCut "$SMPROGRAMS\D\D2 64-bit Command Prompt.lnk" '%comspec%' '/k ""$INSTDIR\dmd2vars64.bat""' "" "" SW_SHOWNORMAL "" "Open D2 64-bit Command Prompt"
   SectionEnd


### PR DESCRIPTION
- Chmgen and the d.chm Windows file are unreasonably unreliable
  there were 4 issues responsible for 39 failing nightly builds in
  2016, which are very time-consuming to debug and fix.
  It seems that the basic approach to parse the html docs into
  structured information is flawed and not sustainable.
- chm files are nice for offline usage, but it's a very minor tool
  on which we spent a very unproportionate amount of resources.
- dman doesn't even offer offline capabilities, and can be easily
  replaced by a browser shortcut to dlang.org's search field.

Also https://github.com/dlang/dlang.org/pull/2212 and https://forum.dlang.org/post/alcerzuvydfutsiuelsk@forum.dlang.org.