### PR TITLE
stop overwriting old-dmd with new libs and binaries

### DIFF
--- a/create_dmd_release/build_all.d
+++ b/create_dmd_release/build_all.d
@@ -226,49 +226,12 @@ auto addPrefix(R)(R rng, string prefix)
 
 void prepareExtraBins(string workDir)
 {
-    auto winBins = [
-        "windbg.hlp", "ddemangle.exe", "lib.exe", "link.exe", "make.exe",
-        "replace.exe", "shell.exe", "windbg.exe", "dm.dll", "eecxxx86.dll",
-        "emx86.dll", "mspdb41.dll", "shcv.dll", "tlloc.dll", "libcurl.dll",
-        "lld-link.exe",
-    ].addPrefix("bin/");
-    auto winBins64 = ["libcurl.dll"].addPrefix("bin64/");
-    auto mingwCoffLibs = [
-        "aclui.lib", "advapi32.lib", "avicap32.lib", "avifil32.lib", "bthprops.lib",
-        "cap.lib", "comctl32.lib", "comdlg32.lib", "crypt32.lib", "ctl3d32.lib",
-        "d3d8.lib", "d3d9.lib", "d3dim.lib", "d3drm.lib", "d3dx8d.lib", "d3dx9d.lib",
-        "d3dxof.lib", "ddraw.lib", "dhcpcsvc.lib", "dinput8.lib", "dinput.lib", "dlcapi.lib",
-        "dnsapi.lib", "dplayx.lib", "dpnaddr.lib", "dpnet.lib", "dpnlobby.lib", "dpvoice.lib",
-        "dsetup.lib", "dsound.lib", "faultrep.lib", "gdi32.lib", "gdiplus.lib", "glaux.lib",
-        "glu32.lib", "icmui.lib", "igmpagnt.lib", "imagehlp.lib", "imm32.lib", "iphlpapi.lib",
-        "kernel32.lib", "ksproxy.lib", "ksuser.lib", "lz32.lib", "mapi32.lib", "mfcuia32.lib",
-        "mgmtapi.lib", "mprapi.lib", "mpr.lib", "mqrt.lib", "msacm32.lib", "mscms.lib",
-        "msdmo.lib", "msimg32.lib", "msvcp60.lib", "msvcrt100.lib", "msvfw32.lib",
-        "mswsock.lib", "nddeapi.lib", "netapi32.lib", "ntdll.lib", "odbc32.lib",
-        "odbccp32.lib", "oldnames.lib", "ole32.lib", "oleacc.lib", "oleaut32.lib",
-        "olecli32.lib", "oledlg.lib", "olepro32.lib", "olesvr32.lib", "opengl32.lib",
-        "penwin32.lib", "pkpd32.lib", "powrprof.lib", "psapi.lib", "quartz.lib",
-        "rapi.lib", "rasapi32.lib", "rasdlg.lib", "rpcdce4.lib", "rpcns4.lib", "rpcrt4.lib",
-        "rtm.lib", "rtutils.lib", "secur32.lib", "setupapi.lib", "shell32.lib", "shfolder.lib",
-        "shlwapi.lib", "snmpapi.lib", "svrapi.lib", "tapi32.lib", "thunk32.lib",
-        "url.lib", "user32.lib", "userenv.lib", "usp10.lib", "uuid.lib", "uxtheme.lib",
-        "vdmdbg.lib", "version.lib", "win32spl.lib", "wininet.lib", "winmm.lib",
-        "winspool.lib", "winstrm.lib", "wldap32.lib", "wow32.lib", "ws2_32.lib",
-        "wsnmp32.lib", "wsock32.lib", "wst.lib", "wtsapi32.lib",
-    ];
-    auto winLibs = [
-        "advapi32.lib", "COMCTL32.LIB", "comdlg32.lib", "CTL3D32.LIB",
-        "gdi32.lib", "kernel32.lib", "ODBC32.LIB", "ole32.lib", "OLEAUT32.LIB",
-        "rpcrt4.lib", "shell32.lib", "snn.lib", "user32.lib", "uuid.lib",
-        "winmm.lib", "winspool.lib", "WS2_32.LIB", "wsock32.lib", "curl.lib",
-        "update_libs.bat",
-    ].addPrefix("lib/");
-    auto winLibs32Coff = (mingwCoffLibs ~ "curl.lib").addPrefix("lib32mscoff/");
-    auto winLibs64 = (mingwCoffLibs ~ "curl.lib").addPrefix("lib64/");
-    auto winFiles = chain(winBins, winBins64, winLibs, winLibs32Coff, winLibs64).array();
-
     auto extraBins = [
-        windows_both : winFiles,
+        windows_both : [
+            "windbg.hlp", "ddemangle.exe", "lib.exe", "link.exe", "make.exe",
+            "replace.exe", "shell.exe", "windbg.exe", "dm.dll", "eecxxx86.dll",
+            "emx86.dll", "mspdb41.dll", "shcv.dll", "tlloc.dll"
+        ].addPrefix("bin/").array,
         linux_both : ["bin32/dumpobj", "bin64/dumpobj", "bin32/obj2asm", "bin64/obj2asm"],
         freebsd_32 : ["bin32/dumpobj", "bin32/obj2asm", "bin32/shell"],
         freebsd_64 : [],
@@ -506,20 +469,12 @@ int main(string[] args)
 
     if (platforms.canFind!(p => p.os == OS.windows))
     {
-        // Use latest optlink
+        // Use latest optlink to build release
         remove(workDir~"/windows/old-dmd/dmd2/windows/bin/link.exe");
         extract(cacheDir~"/"~optlink, workDir~"/windows/old-dmd/dmd2/windows/bin/");
-        // Use latest libC (snn.lib)
+        // Use latest libC (snn.lib) to build release
         remove(workDir~"/windows/old-dmd/dmd2/windows/lib/snn.lib");
         copyFile(cacheDir~"/"~libC, workDir~"/windows/old-dmd/dmd2/windows/lib/"~libC);
-        // Get libcurl for windows
-        extract(cacheDir~"/"~libCurl, workDir~"/windows/old-dmd/");
-        // Get updated OMF import libraries
-        extract(cacheDir~"/"~omflibs, workDir~"/windows/old-dmd/dmd2/windows/lib/");
-        // Get mingw coff libraries
-        extract(cacheDir~"/"~mingwlibs, workDir~"/windows/old-dmd/");
-        // Get lld-link.exe
-        extract(cacheDir~"/"~lld, workDir~"/windows/old-dmd/dmd2/windows/bin/");
     }
 
     cloneSources(gitTag, dubTag, isBranch, skipDocs, workDir~"/clones");
@@ -536,7 +491,21 @@ int main(string[] args)
                 "Mismatch between dmd/VERSION: '"~dmdVer~"' and git tag: '"~gitTag~"'.");
     }
     applyPatches(gitTag, skipDocs, workDir~"/clones");
+
+    // copy weird custom binaries from the previous release
     prepareExtraBins(workDir);
+    // add latest optlink
+    extract(cacheDir~"/"~optlink, workDir~"/windows/extraBins/dmd2/windows/bin/");
+    // add latest dmc libC (snn.lib)
+    copyFile(cacheDir~"/"~libC, workDir~"/windows/extraBins/dmd2/windows/lib/"~libC);
+    // add libcurl build for windows
+    extract(cacheDir~"/"~libCurl, workDir~"/windows/extraBins/");
+    // add updated OMF import libraries
+    extract(cacheDir~"/"~omflibs, workDir~"/windows/extraBins/dmd2/windows/lib/");
+    // add mingw coff libraries
+    extract(cacheDir~"/"~mingwlibs, workDir~"/windows/extraBins/");
+    // add lld linker
+    extract(cacheDir~"/"~lld, workDir~"/windows/extraBins/dmd2/windows/bin/");
 
     immutable ver = gitTag.chompPrefix("v");
     mkdirRecurse("build");

--- a/create_dmd_release/build_all.d
+++ b/create_dmd_release/build_all.d
@@ -228,7 +228,7 @@ void prepareExtraBins(string workDir)
 {
     auto extraBins = [
         windows_both : [
-            "windbg.hlp", "ddemangle.exe", "lib.exe", "link.exe", "make.exe",
+            "windbg.hlp", "lib.exe", "link.exe", "make.exe",
             "replace.exe", "shell.exe", "windbg.exe", "dm.dll", "eecxxx86.dll",
             "emx86.dll", "mspdb41.dll", "shcv.dll", "tlloc.dll"
         ].addPrefix("bin/").array,


### PR DESCRIPTION
- old-dmd is fairly new by now and comes with everything necessary to
  build a release, updating the old release could introduce weird
  issues as it's not really tested
- directly extract libs and bins to extraBins folder that gets packed
  into the release archive