### PR TITLE
Always update the install script

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -342,9 +342,7 @@ run_command() {
     case $1 in
         install)
             check_tools curl
-            if [ ! -f "$ROOT/install.sh" ]; then
-                install_dlang_installer
-            fi
+            install_dlang_installer || log "Updating the installer failed."
             if [ -z "${2:-}" ]; then
                 fatal "Missing compiler argument for $1 command.";
             fi


### PR DESCRIPTION
If we go with this, imho we should reopen https://github.com/dlang/installer/pull/274 (config file) and allow people to opt-out of this.
There are certainly use cases in which always updating the installer can be annoying, especially if you use the install script with an already installed compiler this will add a few seconds extra to every activation.