### PR TITLE
Make the install script compatible with more shells

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,23 @@
 language: c
 
+env:
+ - SHELL=sh
+ - SHELL=zsh
+ - SHELL=ksh
+
 addons:
   apt:
-    # https://github.com/SimonKagstrom/kcov/blob/master/INSTALL.md#user-content-ubuntu
-    packages: [shellcheck, binutils-dev, libcurl4-openssl-dev, zlib1g-dev, libdw-dev, libiberty-dev]
+    packages: [zsh, ksh]
+
+
+script: "$SHELL ./travis.sh"
 
 matrix:
   include:
     - os: linux
+      addons:
+        apt:
+          packages: [shellcheck, binutils-dev, libcurl4-openssl-dev, zlib1g-dev, libdw-dev, libiberty-dev]
       install:
         - KCOV_VERSION=34
         - curl -fsSL https://github.com/SimonKagstrom/kcov/archive/v"$KCOV_VERSION".tar.gz | tar -C "$HOME" -zxf -

--- a/script/install.sh
+++ b/script/install.sh
@@ -616,7 +616,7 @@ verify() {
         log "Downloading https://dlang.org/d-keyring.gpg"
         download_without_verify "$ROOT/d-keyring.gpg" "${keyring_mirrors[@]}"
     fi
-    if ! $GPG -q --verify --keyring "$ROOT/d-keyring.gpg" --no-default-keyring <(fetch "${urls[@]}") "$path" 2>/dev/null; then
+    if ! fetch "${urls[@]}" | $GPG -q --verify --keyring "$ROOT/d-keyring.gpg" --no-default-keyring - "$path" 2>/dev/null ; then
         fatal "Invalid signature ${urls[0]}"
     fi
 }

--- a/travis.sh
+++ b/travis.sh
@@ -2,6 +2,8 @@
 
 set -uexo pipefail
 
+echo $SHELL
+
 compilers=(
     dmd-2.069.2
     dmd-2.071.2
@@ -52,7 +54,7 @@ for idx in "${!compilers[@]}"
 do
     compiler="${compilers[$idx]}"
     echo "Testing: $compiler"
-    ./script/install.sh $compiler
+    $SHELL ./script/install.sh $compiler
 
     . ~/dlang/$compiler/activate
     compilerVersion=$($DC --version | sed -n 1p)
@@ -63,17 +65,17 @@ do
 
     # Check whether the compilers have been successfully installed
     touch "$testFile".d
-    source $(./script/install.sh $compiler --activate)
+    source $($SHELL ./script/install.sh $compiler --activate)
     ${DMD} "-of${testFile}" "${testFile}.d"
     test "$(${testFile})" = "${frontendVersions[$idx]}"
     rm ${testFile}
     deactivate
 
-    source $(./script/install.sh $compiler -a)
+    source $($SHELL ./script/install.sh $compiler -a)
     command -v dub >/dev/null 2>&1 || { echo >&2 "DUB hasn't been installed."; exit 1; }
     deactivate
 
-    ./script/install.sh uninstall $compiler
+    $SHELL ./script/install.sh uninstall $compiler
 done
 
 # test resolution of latest using the remove error message
@@ -81,7 +83,7 @@ latest=(dmd dmd-beta dmd-master dmd-nightly ldc ldc-beta gdc)
 for compiler in "${latest[@]}"
 do
     set +e
-    resolved=$(./script/install.sh remove "$compiler" 2>&1)
+    resolved=$($SHELL ./script/install.sh remove "$compiler" 2>&1)
     set -e
     if ! [[ $resolved =~ ^${compiler%-*}-(.+)$ ]]; then
         echo "Failed to resolve $compiler, got '$resolved'"
@@ -91,25 +93,25 @@ done
 cmds=(install uninstall list update)
 for cmd in "${cmds[@]}"
 do
-    ./script/install.sh --help | grep -F "$cmd" >/dev/null
-    ./script/install.sh -h | grep -F "$cmd" >/dev/null
-    ./script/install.sh "$cmd" --help | tr -d '\n' | grep -q "Usage\s*install.sh $cmd" >/dev/null
-    ./script/install.sh "$cmd" -h | tr -d '\n' | grep -q "Usage\s*install.sh $cmd" >/dev/null
+    $SHELL /script/install.sh --help | grep -F "$cmd" >/dev/null
+    $SHELL /script/install.sh -h | grep -F "$cmd" >/dev/null
+    $SHELL /script/install.sh "$cmd" --help | tr -d '\n' | grep -q "Usage\s*install.sh $cmd" >/dev/null
+    $SHELL /script/install.sh "$cmd" -h | tr -d '\n' | grep -q "Usage\s*install.sh $cmd" >/dev/null
 done
 # remove is alias for uninstall
-./script/install.sh remove --help | tr -d '\n' | grep "Usage\s*install.sh uninstall" >/dev/null
-./script/install.sh remove -h | tr -d '\n' | grep "Usage\s*install.sh uninstall" >/dev/null
+$SHELL ./script/install.sh remove --help | tr -d '\n' | grep "Usage\s*install.sh uninstall" >/dev/null
+$SHELL ./script/install.sh remove -h | tr -d '\n' | grep "Usage\s*install.sh uninstall" >/dev/null
 
 # check whether all installations have been uninstalled successfully
-if bash script/install.sh list
+if $SHELL script/install.sh list
 then
     echo "Uninstall of the compilers failed."
     exit 1
 fi
 
 # test in-place update
-bash script/install.sh update --path "$PWD/script"
-bash script/install.sh update -p "$PWD/script"
+$SHELL script/install.sh update --path "$PWD/script"
+$SHELL script/install.sh update -p "$PWD/script"
 # reset script
 git checkout -- script/install.sh
 


### PR DESCRIPTION
Process substitution is availably only in bash/zsh, but not in general for sh.

https://superuser.com/questions/1059781/what-exactly-is-in-bash-and-in-zsh

This is an effort to allow using the installer on platforms on which bash isn't installed.
Also `curl ... | sh` would be nice to use eventually.