### PR TITLE
fix Issue 18649 - curl on Ubuntu 18.04 depends on libcurl4, ...

### DIFF
--- a/linux/dmd_deb.sh
+++ b/linux/dmd_deb.sh
@@ -344,8 +344,8 @@ else
 
 
 	# set deb package dependencies
-	DEPENDS="libc6, libc6-dev, gcc, libgcc1, libstdc++6, libcurl3"
-	SUGGESTS="libcurl4-openssl-dev, gcc-multilib"
+	DEPENDS='libc6, libc6-dev, gcc, libgcc1, libstdc++6, libcurl4 | libcurl3'
+	SUGGESTS='gcc-multilib, libcurl4-openssl-dev | libcurl4-gnutls-dev | libcurl4-nss-dev'
 
 
 	# create control file

--- a/linux/dmd_phobos.sh
+++ b/linux/dmd_phobos.sh
@@ -203,7 +203,7 @@ else
 
 
 	# set deb package dependencies
-	DEPENDS="libc6, libcurl3"
+	DEPENDS="libc6, libcurl4 | libcurl3"
 
 
 	# create control file

--- a/test/.gitignore
+++ b/test/.gitignore
@@ -1,0 +1,3 @@
+*.rpm
+*.deb
+Dockerfile

--- a/test/installation.sh
+++ b/test/installation.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+cd "$(dirname "$0")"
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 [version (e.g. 2.079.1)]" 1>&2
+    exit 1
+fi
+VERSION="$1"
+
+: ${BUILD_DIR:='../create_dmd_release/build'}
+DEB="dmd_$VERSION-0_amd64.deb"
+# TODO: test rpms
+#RPM="$BUILD_DIR/dmd-$VERSION-0.fedora.x86_64.rpm"
+#SUSE_RPM="$BUILD_DIR/dmd-$VERSION-0.openSUSE.x86_64.rpm"
+DEB_PLATFORMS=(ubuntu:precise ubuntu:trusty ubuntu:xenial ubuntu:bionic)
+DEB_PLATFORMS+=(debian:wheezy debian:jessie debian:stretch)
+
+# copy pkgs to test folder so that it's part of docker's build context
+cp "$BUILD_DIR/dmd_$VERSION-0_amd64.deb" .
+# TODO: test rpms
+#cp "$BUILD_DIR/dmd-$VERSION-0.fedora.x86_64.rpm" .
+#cp "$BUILD_DIR/dmd-$VERSION-0.openSUSE.x86_64.rpm" .
+
+trap 'echo -e "\e[1;31mOuter script failed at line $LINENO.\e[0m"' ERR
+
+for platform in "${DEB_PLATFORMS[@]}"; do
+    echo -e "\e[1;33mTesting installation of $DEB on $platform.\e[0m"
+    img_tag="test_${platform//:/_}"
+    # build docker image containing package
+    cat > Dockerfile <<EOF
+FROM $platform
+COPY test_curl.d .
+COPY $DEB .
+EOF
+    docker build . --tag="$img_tag" >/dev/null
+
+    # test installation
+    docker run --rm -i "$img_tag" bash -s <<EOF
+set -euo pipefail
+
+trap 'echo -e "\e[1;31mInner script failed at line \$LINENO.\e[0m"' ERR
+set -x
+
+apt-get update -q=2 >/dev/null
+apt-get install curl -q=2 >/dev/null
+dpkg -i $DEB || true
+apt-get --fix-broken install -q=2 >/dev/null
+# check that both dmd and curl are still installed
+dpkg-query -W --showformat='\${Status}\n' dmd | grep -F 'install ok installed'
+dpkg-query -W --showformat='\${Status}\n' curl | grep -F 'install ok installed'
+curl --version >/dev/null
+# run a complex D hello world (using libcurl)
+dmd -run test_curl.d
+EOF
+
+    # remove docker image
+    docker rmi "$img_tag" >/dev/null
+    rm Dockerfile
+done

--- a/test/test_curl.d
+++ b/test/test_curl.d
@@ -1,0 +1,29 @@
+import std.net.curl, std.stdio;
+
+int main()
+{
+    // test a couple of domains for resilience against server, DNS, and network failures
+    foreach (dmn; ["dlang.org", "dconf.org", "downloads.dlang.org", "ci.dlang.io"])
+    {
+        try
+        {
+            auto res = get(dmn);
+            if (res.length)
+            {
+                writeln("Succeeded to GET ", dmn);
+                return 0;
+            }
+            else
+            {
+                stderr.writeln("GET ", dmn, " returned an empty result");
+                return 1;
+            }
+        }
+        catch (Throwable e)
+        {
+            stderr.writeln("Failed to GET ", dmn);
+            stderr.writeln(e.message);
+        }
+    }
+    return 1;
+}


### PR DESCRIPTION
... .deb installer depends on libcurl3

- depend on libcurl4 | libcurl3 alternative
- degrading libcurl from dependency to recommends would be welcome,
  but does not work because recommendations are not installed for raw
  .deb packages (--fix-broken only installs dependencies).
  `dpkg -i dmd_2.079.1-0_amd64.deb && apt-get --fix-broken install`
- also add suggested libcurl-dev alternative
- also add install test script for supported debian and ubuntu releases

Supersedes #314