### PR TITLE
Make install.sh group-writable

### DIFF
--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -4,8 +4,13 @@ set -uexo pipefail
 
 ROOT=$(dirname $0)
 
+function rsync_with_perms()
+{
+    rsync --perms --chmod=u+rw,g+rw,o+r "$@"
+}
+
 ${GPG:-gpg2} --detach-sign install.sh
-scp "$ROOT/install.sh" "$ROOT/install.sh.sig" digitalmars.com:/usr/local/www/dlang.org/data/
-scp "$ROOT/install.sh" "$ROOT/install.sh.sig" nightlies.dlang.org:/var/www/builds/
+rsync_with_perms "$ROOT/install.sh" "$ROOT/install.sh.sig" digitalmars.com:/usr/local/www/dlang.org/data/
+rsync_with_perms "$ROOT/install.sh" "$ROOT/install.sh.sig" nightlies.dlang.org:/var/www/builds/
 aws --profile ddo s3 cp "$ROOT/install.sh" s3://downloads.dlang.org/other/ --acl public-read --cache-control max-age=604800
 aws --profile ddo s3 cp "$ROOT/install.sh.sig" s3://downloads.dlang.org/other/ --acl public-read --cache-control max-age=604800


### PR DESCRIPTION
This should allow the install.sh script to stay group-writable by the dlang.org group.