### PR TITLE
Minor install script deploy improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ osx/dmg
 *.dmg
 .DS_Store
 coverage/
+script/install.sh.sig

--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -4,7 +4,9 @@ set -uexo pipefail
 
 ROOT=$(dirname $0)
 
-${GPG:-gpg2} --detach-sign install.sh
+rm -f $ROOT/install.sh.sig
+${GPG:-gpg2} --detach-sign $ROOT/install.sh
+
 scp "$ROOT/install.sh" "$ROOT/install.sh.sig" digitalmars.com:/usr/local/www/dlang.org/data/
 scp "$ROOT/install.sh" "$ROOT/install.sh.sig" nightlies.dlang.org:/var/www/builds/
 aws --profile ddo s3 cp "$ROOT/install.sh" s3://downloads.dlang.org/other/ --acl public-read --cache-control max-age=604800


### PR DESCRIPTION
- gitignore of the signature file
- remove the old signature file, s.t. gpg can't silently fail and we don't notice
- cd to ROOT, s.t. we can run the script from anywhere