### PR TITLE
Build the newest version of MinGW

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ os: Visual Studio 2017
 environment:
   matrix:
     - ARCH:                x86
-      MINGW_VER:           5.0.2
+      MINGW_VER:           5.0.4
       D_VERSION:           2.077.1
 
 artifacts:


### PR DESCRIPTION
We currently use a more than one year old release: https://mingw-w64.org/doku.php/versions