### PR TITLE
Issue 19051 - Undefined functions Set/GetWindowLongPtr in mingw libs

### DIFF
--- a/windows/mingw/buildsdk.d
+++ b/windows/mingw/buildsdk.d
@@ -54,6 +54,20 @@ bool def2implib(bool x64, string f, string dir, string linkopt = null)
     if (pos < 0)
         return false;
 
+    string base = stripExtension(baseName(f));
+    if (x64 && base == "user32")
+    {
+        // missing definitions in mingw def files
+        content ~= "GetClassLongPtrA\n";
+        content ~= "GetClassLongPtrW\n";
+        content ~= "SetClassLongPtrA\n";
+        content ~= "SetClassLongPtrW\n";
+        content ~= "GetWindowLongPtrA\n";
+        content ~= "GetWindowLongPtrW\n";
+        content ~= "SetWindowLongPtrA\n";
+        content ~= "SetWindowLongPtrW\n";
+    }
+
     char[] def = content[0..pos];
     char[] csrc;
     bool[string] written;
@@ -99,7 +113,6 @@ bool def2implib(bool x64, string f, string dir, string linkopt = null)
             written[sym.idup] = true;
         }
     }
-    string base = stripExtension(baseName(f));
     string dirbase = dir ~ base;
     std.file.write(dirbase ~ ".def", def);
     std.file.write(dirbase ~ ".c", csrc);


### PR DESCRIPTION
these symbols do not exist for Win32 and are still missing in the 6.0 branch for mingw: https://sourceforge.net/p/mingw/mingw-org-wsl/ci/6.0-exp/tree/wslapi/lib/

mingw-w64 has them (https://github.com/mirror/mingw-w64/blob/master/mingw-w64-crt/lib-common/user32.def.in#L849) but basing the generation on a different distro is not (yet) reasonable.