### PR TITLE
fix uninitialised suffix on macOS

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -630,7 +630,7 @@ verify() {
 binpath_for_compiler() {
     case $1 in
         dmd*)
-            local suffix
+            local suffix=
             [ $OS = osx ] || suffix=$MODEL
             local -r binpath=$OS/bin$suffix
             ;;
@@ -650,7 +650,7 @@ write_env_vars() {
     local -r binpath=$(binpath_for_compiler "$1")
     case $1 in
         dmd*)
-            local suffix
+            local suffix=
             [ $OS = osx ] || suffix=$MODEL
             local libpath=$OS/lib$suffix
             local dc=dmd


### PR DESCRIPTION
The problem was introduced in https://github.com/dlang/installer/pull/239 and presumable copied in https://github.com/dlang/installer/pull/218