### PR TITLE
less gnu-y alternative to find -printf

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -759,7 +759,7 @@ list_compilers() {
              -not -name install.sh \
              -not -name d-keyring.gpg \
              -not -name '.*' \
-             -printf "%f\n" | \
+             -exec basename {} \; | \
             grep . # fail if none found
     fi
 }


### PR DESCRIPTION
because not everywhere has gnu tools (e.g. macOS)