### PR TITLE
Use language:generic for Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: c
+language: minimal
 
 addons:
   apt:


### PR DESCRIPTION
According to https://github.com/travis-ci/travis-ci/issues/4895#issuecomment-150703192o

To avoid issues like https://github.com/dlang/installer/pull/335 or https://github.com/dlang/installer/pull/334