### PR TITLE
update install.sh script for new ddo nightlies

### DIFF
--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -8,6 +8,5 @@ rm -f $ROOT/install.sh.sig
 ${GPG:-gpg2} --detach-sign $ROOT/install.sh
 
 scp "$ROOT/install.sh" "$ROOT/install.sh.sig" digitalmars.com:/usr/local/www/dlang.org/data/
-scp "$ROOT/install.sh" "$ROOT/install.sh.sig" nightlies.dlang.org:/var/www/builds/
 aws --profile ddo s3 cp "$ROOT/install.sh" s3://downloads.dlang.org/other/ --acl public-read --cache-control max-age=604800
 aws --profile ddo s3 cp "$ROOT/install.sh.sig" s3://downloads.dlang.org/other/ --acl public-read --cache-control max-age=604800

--- a/script/install.sh
+++ b/script/install.sh
@@ -406,11 +406,11 @@ install_dlang_installer() {
     tmp=$(mkdtemp)
     local mirrors=(
         "https://dlang.org/install.sh"
-        "https://nightlies.dlang.org/install.sh"
+        "https://s3-us-west-2.amazonaws.com/downloads.dlang.org/other/install.sh"
     )
     local keyring_mirrors=(
         "https://dlang.org/d-keyring.gpg"
-        "https://nightlies.dlang.org/d-keyring.gpg"
+        "https://s3-us-west-2.amazonaws.com/downloads.dlang.org/other/d-keyring.gpg"
     )
 
     mkdir -p "$ROOT"
@@ -455,11 +455,13 @@ resolve_latest() {
             # but not: dmd-2016-10-19 or dmd-branch-2016-10-20
             #          dmd-2.068.0 or dmd-2.068.2-5
             if [[ ! $COMPILER =~ -[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] &&
-               [[ ! $COMPILER =~ -[0-9][.][0-9]{3}[.][0-9]{1,3}(-[0-9]{1,3})? ]]
-            then
-                local url=http://nightlies.dlang.org/$COMPILER/LATEST
+               [[ ! $COMPILER =~ -[0-9][.][0-9]{3}[.][0-9]{1,3}(-[0-9]{1,3})? ]]; then
+                local url=http://downloads.dlang.org/nightlies/$COMPILER/LATEST
                 logV "Determing latest $COMPILER version ($url)."
                 COMPILER="dmd-$(fetch "$url")"
+            # rewrite dmd-2016-10-19 -> dmd-master-2016-10-19 (default branch for nightlies)
+            elif [[ $COMPILER =~ ^dmd-([0-9]{4}-[0-9]{2}-[0-9]{2})$ ]]; then
+                COMPILER="dmd-master-${BASH_REMATCH[1]}"
             fi
             ;;
         ldc)
@@ -523,7 +525,7 @@ install_compiler() {
         if [ $OS = freebsd ]; then
             basename="$basename-$MODEL"
         fi
-        local url="http://nightlies.dlang.org/$1/$basename.tar.xz"
+        local url="http://downloads.dlang.org/nightlies/$1/$basename.tar.xz"
 
         download_and_unpack_with_verify "$ROOT/$compiler" "$url"
 
@@ -623,6 +625,7 @@ verify() {
         return
     fi
     if ! $GPG -q --verify --keyring "$ROOT/d-keyring.gpg" --no-default-keyring <(fetch "${urls[@]}") "$path" 2>/dev/null; then
+        rm "$path" # delete invalid files
         fatal "Invalid signature ${urls[0]}"
     fi
 }

--- a/travis.sh
+++ b/travis.sh
@@ -6,8 +6,7 @@ compilers=(
     dmd-2.069.2
     dmd-2.071.2
     dmd-2.077.1
-    dmd-2016-10-19
-    dmd-master-2016-10-24
+    dmd-master-2018-10-14
     ldc-1.4.0
 )
 
@@ -15,8 +14,7 @@ versions=(
     'DMD64 D Compiler v2.069.2'
     'DMD64 D Compiler v2.071.2'
     'DMD64 D Compiler v2.077.1'
-    'DMD64 D Compiler v2.073.0-master-878b882'
-    'DMD64 D Compiler v2.073.0-master-ab9d712'
+    'DMD64 D Compiler v2.082.1-master-54b676b'
     'LDC - the LLVM D compiler (1.4.0):'
 )
 
@@ -24,8 +22,7 @@ frontendVersions=(
     '2069'
     '2071'
     '2077'
-    '2073'
-    '2073'
+    '2082'
     '2074'
 )
 
@@ -77,7 +74,7 @@ do
 done
 
 # test resolution of latest using the remove error message
-latest=(dmd dmd-beta dmd-master dmd-nightly ldc ldc-beta gdc)
+latest=(dmd dmd-beta dmd-master dmd-nightly ldc ldc-beta gdc dmd-2018-10-14)
 for compiler in "${latest[@]}"
 do
     set +e


### PR DESCRIPTION
- replace all nightlies.dlang.org URLs with downloads.dlang.org/nightlies
- quite some changes due to losing an alternative HTTPS download source
- rewrite dmd-2018-10-14 to dmd-master-2018-10-14 in the script so to
  not clutter the download page with plenty of confusing symlinks