### PR TITLE
Issue 19716 Add MANPATH to activate(.fish)

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -381,7 +381,7 @@ run_command() {
             else
                 log "
 Run \`source $ROOT/$2/activate${suffix:-}\` in your shell to use $2.
-This will setup PATH, LIBRARY_PATH, LD_LIBRARY_PATH, DMD, DC, and PS1.
+This will setup PATH, LIBRARY_PATH, LD_LIBRARY_PATH, MANPATH, DMD, DC, and PS1.
 Run \`deactivate\` later on to restore your environment."
             fi
             ;;
@@ -715,11 +715,13 @@ deactivate() {
     export PATH="\$_OLD_D_PATH"
     export LIBRARY_PATH="\$_OLD_D_LIBRARY_PATH"
     export LD_LIBRARY_PATH="\$_OLD_D_LD_LIBRARY_PATH"
+    export MANPATH="\$_OLD_D_MANPATH"
     export PS1="\$_OLD_D_PS1"
 
     unset _OLD_D_PATH
     unset _OLD_D_LIBRARY_PATH
     unset _OLD_D_LD_LIBRARY_PATH
+    unset _OLD_D_MANPATH
     unset _OLD_D_PS1
     unset DMD
     unset DC
@@ -729,11 +731,13 @@ deactivate() {
 _OLD_D_PATH="\${PATH:-}"
 _OLD_D_LIBRARY_PATH="\${LIBRARY_PATH:-}"
 _OLD_D_LD_LIBRARY_PATH="\${LD_LIBRARY_PATH:-}"
+_OLD_D_MANPATH="\${MANPATH:-}"
 _OLD_D_PS1="\${PS1:-}"
 
 export PATH="${DUB_BIN_PATH}${DUB_BIN_PATH:+:}$ROOT/$1/$binpath\${PATH:+:}\${PATH:-}"
 export LIBRARY_PATH="$ROOT/$1/$libpath\${LIBRARY_PATH:+:}\${LIBRARY_PATH:-}"
 export LD_LIBRARY_PATH="$ROOT/$1/$libpath\${LD_LIBRARY_PATH:+:}\${LD_LIBRARY_PATH:-}"
+export MANPATH="$ROOT/$1/man:\${MANPATH:-}"
 export DMD=$dmd
 export DC=$dc
 export PS1="($1)\${PS1:-}"
@@ -745,6 +749,7 @@ function deactivate
     set -gx PATH \$_OLD_D_PATH
     set -gx LIBRARY_PATH \$_OLD_D_LIBRARY_PATH
     set -gx LD_LIBRARY_PATH \$_OLD_D_LD_LIBRARY_PATH
+    set -gx MANPATH \$_OLD_D_MANPATH
 
     functions -e fish_prompt
     functions -c _old_d_fish_prompt fish_prompt
@@ -753,6 +758,7 @@ function deactivate
     set -e _OLD_D_PATH
     set -e _OLD_D_LIBRARY_PATH
     set -e _OLD_D_LD_LIBRARY_PATH
+    set -e _OLD_D_MANPATH
     set -e DMD
     set -e DC
     functions -e deactivate
@@ -761,11 +767,14 @@ end
 set -g _OLD_D_PATH \$PATH
 set -g _OLD_D_LIBRARY_PATH \$LIBRARY_PATH
 set -g _OLD_D_LD_LIBRARY_PATH \$LD_LIBRARY_PATH
+set -g _OLD_D_MANPATH \$MANPATH
 set -g _OLD_D_PS1 \$PS1
 
 set -gx PATH ${DUB_BIN_PATH:+\'}${DUB_BIN_PATH}${DUB_BIN_PATH:+\' }'$ROOT/$1/$binpath' \$PATH
 set -gx LIBRARY_PATH '$ROOT/$1/$libpath' \$LIBRARY_PATH
 set -gx LD_LIBRARY_PATH '$ROOT/$1/$libpath' \$LD_LIBRARY_PATH
+set -q MANPATH; or set MANPATH ''
+set -gx MANPATH '$ROOT/$1/man' \$MANPATH
 set -gx DMD $dmd
 set -gx DC $dc
 functions -c fish_prompt _old_d_fish_prompt


### PR DESCRIPTION
Add the MANPATH environment variable to both the `activate` and `activate.fish` generated scripts in `install.sh`. Gives access to man pages for, e.g., dmd and dmd.conf.