### PR TITLE
Upgrade MinGW to 6.0.0

### DIFF
--- a/changelog/mingw-6.dd
+++ b/changelog/mingw-6.dd
@@ -1,0 +1,3 @@
+The bundled Windows libraries have been changed from MinGW to MinGW-w64.
+
+The bundled Windows libraries and definitions have been changed from MinGW 5.0.2 to MinGW 7.0.0.

--- a/create_dmd_release/build_all.d
+++ b/create_dmd_release/build_all.d
@@ -491,7 +491,7 @@ int main(string[] args)
     enum libC = "snn.lib";
     enum libCurl = "libcurl-7.64.0-WinSSL-zlib-x86-x64.zip";
     enum omflibs = "omflibs-winsdk-10.0.16299.15.zip";
-    enum mingwlibs = "mingw-libs-5.0.2-1.zip";
+    enum mingwlibs = "mingw-libs-7.0.0.zip";
     enum lld = "lld-link-8.0.0.zip";
 
     auto oldCompilers = platforms


### PR DESCRIPTION
Upgrade the installer to use the Mingw 6 definitions from https://github.com/dlang/installer/pull/346.
Would be great if someone can give this a quick test, s.t. we can ship with with the upcoming 2.086 beta.

This could fix:
- https://issues.dlang.org/show_bug.cgi?id=19773