### PR TITLE
MinGW-w64 libs: Fix DLL entry point

### DIFF
--- a/windows/mingw/msvcrt_stub.c
+++ b/windows/mingw/msvcrt_stub.c
@@ -39,10 +39,13 @@ extern int __ref_oldnames;
 
 #if _APPTYPE == __UNKNOWN_APP
 
+extern BOOL WINAPI DllMain (HINSTANCE, DWORD, LPVOID);
+
 BOOL WINAPI
-DllMainCRTStartup (HANDLE hDll, DWORD dwReason, LPVOID lpReserved)
+_DllMainCRTStartup (HINSTANCE hDll, DWORD dwReason, LPVOID lpReserved)
 {
     BOOL bRet;
+    __ref_oldnames = 0; // drag in alternate definitions
 
     if (dwReason == DLL_PROCESS_ATTACH)
     {


### PR DESCRIPTION
This should fix the issues in https://forum.dlang.org/thread/uxmbtqqdomrrsnrssapc@forum.dlang.org.

I've tested linking the following DLL (with LDC), as both x86/x64 and with both msvcrt100.lib (2010) and vcruntime140.lib (2015), and it works:
```D
import core.sys.windows.windows;

extern(Windows) BOOL DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
{
    return FALSE;
}

export void foo()
{
    import core.stdc.stdlib : malloc, free;
    auto blub = malloc(1024);
    free(blub);
}
```