### PR TITLE
fix issue 20120 - libcurl.dll hangs when running std.net.curl unittests

### DIFF
--- a/windows/build_curl.bat
+++ b/windows/build_curl.bat
@@ -43,7 +43,7 @@ SET PATH=%MINGW_PATH%;%ORIG_PATH%
 call "c:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
 
 mingw32-make -C zlib -f win32\Makefile.gcc || exit /B 1
-mingw32-make -C curl\lib -f Makefile.m32 CFG=mingw32-winssl-zlib-ipv6 LDFLAGS=-static || exit /B 1
+mingw32-make -C curl\lib -f Makefile.m32 CFG=mingw32-winssl-zlib-ipv6 LDFLAGS=-static CURL_CFLAG_EXTRAS=-DDONT_USE_RECV_BEFORE_SEND_WORKAROUND || exit /B 1
 strip -s curl\lib\libcurl.dll
 
 mkdir dmd2\windows\bin dmd2\windows\lib
@@ -64,7 +64,7 @@ SET PATH=%MINGW64_PATH%;%ORIG_PATH%
 call "c:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x64
 
 mingw32-make -C zlib -f win32\Makefile.gcc || exit /B 1
-mingw32-make -C curl\lib -f Makefile.m32 CFG=mingw32-winssl-zlib-ipv6 LDFLAGS=-static || exit /B 1
+mingw32-make -C curl\lib -f Makefile.m32 CFG=mingw32-winssl-zlib-ipv6 LDFLAGS=-static CURL_CFLAG_EXTRAS=-DDONT_USE_RECV_BEFORE_SEND_WORKAROUND || exit /B 1
 strip -s curl\lib\libcurl.dll
 
 mkdir dmd2\windows\bin64 dmd2\windows\lib64


### PR DESCRIPTION
disable the workaround introduced in https://github.com/curl/curl/commit/72d5e144fbc6a9db264ae425bb788af218f25d9e
as it is causing the issue and the curl developers were not really convinced

disabled by defining DONT_USE_RECV_BEFORE_SEND_WORKAROUND when compiling curl