### PR TITLE
remove link.exe/optlink.exe from the old compiler only if they exist

### DIFF
--- a/create_dmd_release/build_all.d
+++ b/create_dmd_release/build_all.d
@@ -524,7 +524,10 @@ int main(string[] args)
     if (platforms.canFind!(p => p.os == OS.windows))
     {
         // Use latest optlink to build release
-        remove(workDir~"/windows/old-dmd/dmd2/windows/bin/link.exe");
+        if (exists(workDir~"/windows/old-dmd/dmd2/windows/bin/link.exe"))
+            remove(workDir~"/windows/old-dmd/dmd2/windows/bin/link.exe");
+        if (exists(workDir~"/windows/old-dmd/dmd2/windows/bin/optlink.exe"))
+            remove(workDir~"/windows/old-dmd/dmd2/windows/bin/optlink.exe");
         extract(cacheDir~"/"~optlink, workDir~"/windows/old-dmd/dmd2/windows/bin/");
         // Use latest libC (snn.lib) to build release
         remove(workDir~"/windows/old-dmd/dmd2/windows/lib/snn.lib");


### PR DESCRIPTION
Just noticed that the release build fails due to link.exe no longer existing. Does the build actually use the latest rc to rebuild itself?

@MartinNowak Sorry for the trouble.