### PR TITLE
script/install.sh: Add initial Windows support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: minimal
+language: bash
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,7 @@ matrix:
         - popd
       script: kcov --exclude-pattern=travis.sh $PWD/coverage ./test/all.sh
       after_success: bash <(curl -s https://codecov.io/bash) -s $PWD/coverage
+    - os: windows
+      script: ./test/all.sh
     - os: osx
       script: ./test/all.sh

--- a/changelog/install-sh-windows.dd
+++ b/changelog/install-sh-windows.dd
@@ -1,0 +1,8 @@
+The install script now runs on Windows
+
+The D installation script (install.sh, available at
+$(LINK2 https://dlang.org/install.sh, dlang.org/install.sh))
+now supports POSIX-like environments on Windows.
+This allows installing and using Windows versions of DMD, LDC, and Dub
+from e.g. CygWin or MSys2, thus providing a unified way of installing
+D compilers across supported platforms.

--- a/script/install.sh
+++ b/script/install.sh
@@ -745,7 +745,7 @@ verify() {
         fatal "Broken GPG installation"
     fi
     local out
-    if ! out=$($GPG -q --verify --keyring "$ROOT/d-keyring.gpg" --no-default-keyring <(fetch "${urls[@]}") "$path" 2>&1); then
+    if ! out=$(fetch "${urls[@]}" | $GPG -q --verify --keyring "$ROOT/d-keyring.gpg" --no-default-keyring - "$path" 2>&1); then
         rm "$path" # delete invalid files
         logE "$out"
         fatal "Invalid signature ${urls[0]}"

--- a/script/install.sh
+++ b/script/install.sh
@@ -744,8 +744,10 @@ verify() {
     if ! $GPG --list-keys >/dev/null; then
         fatal "Broken GPG installation"
     fi
-    if ! $GPG -q --verify --keyring "$ROOT/d-keyring.gpg" --no-default-keyring <(fetch "${urls[@]}") "$path" 2>/dev/null; then
+    local out
+    if ! out=$($GPG -q --verify --keyring "$ROOT/d-keyring.gpg" --no-default-keyring <(fetch "${urls[@]}") "$path" 2>&1); then
         rm "$path" # delete invalid files
+        logE "$out"
         fatal "Invalid signature ${urls[0]}"
     fi
 }

--- a/test/t/dub.sh
+++ b/test/t/dub.sh
@@ -8,33 +8,40 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/../
 compilers=(
     dub-1.10.0
     dub-1.11.0
-    dmd-2.079.0,dub-1.12.0
+    dmd-2.080.0,dub-1.14.0
 )
 
 versions=(
-    'DUB version 1.10.0, built on Jul  3 2018'
-    'DUB version 1.11.0, built on Sep  1 2018'
-    'DUB version 1.12.0, built on Nov  1 2018'
+    'DUB version 1.10.0, built on '
+    'DUB version 1.11.0, built on '
+    'DUB version 1.14.0, built on '
 )
 
 for idx in "${!compilers[@]}"
 do
     compiler="${compilers[$idx]}"
+
+    if [[ "${TRAVIS_OS_NAME:-}" == "windows" && "$compiler" == *dub-1.14.0 ]]; then
+        continue # https://github.com/dlang/dub/issues/1795
+    fi
+
     echo "Testing: $compiler"
     "$INSTALLER" $compiler
     . $("$INSTALLER" $compiler -a)
 
-    compilerVersion=$(dub --version | sed -n 1p)
-    test "$compilerVersion" = "${versions[$idx]}"
+    compilerVersion=$(dub --version | sed -n 1p | tr -d '\r')
+    [[ "$compilerVersion" == "${versions[$idx]}"* ]]
     deactivate
 
     "$INSTALLER" uninstall $compiler
 done
 
 # test latest dub works
-"$INSTALLER" dmd-2.079.0,dub
+"$INSTALLER" dmd-2.080.0,dub
 . $("$INSTALLER" $compiler -a)
-dub --version
+if [ "${TRAVIS_OS_NAME:-}" != "windows" ]; then # https://github.com/dlang/dub/issues/1795
+    dub --version
+fi
 
 deactivate
 "$INSTALLER" uninstall $compiler


### PR DESCRIPTION
Supports installing Windows binaries of DMD, LDC, and Dub on Windows, including nightlies, when running in POSIX-like environments such as MSYS.

Tests pass under MSys2 and CygWin for me.