### PR TITLE
Don't panic on unzip warnings.

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -670,7 +670,9 @@ unpack_zip() {
         if command -v 7z &>/dev/null; then
             7z x -o"$dir" "$zip" 1>&2
         else
-            unzip -q -d "$dir" "$zip"
+            # Allow unzip to exit with code 1, which it uses to signal warnings such as
+            # ".zip appears to use backslashes as path separators"
+            unzip -q -d "$dir" "$zip" || [ "$?" -le "1" ]
         fi
     )
 }


### PR DESCRIPTION
Unzipping a Windows `.zip` using a Posix `unzip` produces the warning `.zip appears to use backslashes as path separators`. This is harmless and should not cause the script to terminate. It occurs when `install.sh` is run in MSYS2 if 7z is not installed.