### PR TITLE
Properly handle path arguments in Windows format.

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -289,7 +289,11 @@ parse_args() {
                     fatal '-p|--path must be followed by a path.';
                 fi
                 shift
-                ROOT="$1"
+                if command -v cygpath &>/dev/null; then
+                    ROOT="$(cygpath "${1}")";
+                else
+                    ROOT="$1"
+                fi
                 ;;
 
             -v | --verbose)


### PR DESCRIPTION
Properly handle path arguments in Windows format like `-p %APPDATA%\dlang`. Without this conversion, an initial invocation of `\msys64\usr\bin\bash.exe -l %APPDATA%\dlang\install.sh -p %APPDATA%\dlang ldc` will fail with "gpg: invalid key resource URL 'C:\Users\me\AppData\Roaming\dlang/d-keyring.gpg'".