### PR TITLE
do not build dub with debug info

### DIFF
--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -546,10 +546,22 @@ void buildAll(Bits bits, string branch, bool dmdOnly=false)
         // too easily with the latest compiler, e.g. for nightlies
         info("Building Dub "~bitsDisplay);
         changeDir(cloneDir~"/dub");
-        version (Windows)
-            run("SET DC="~hostDMD~" && build.cmd -m"~bitsStr); // TODO: replace DC with DMD
+
+        if (exists("build.d"))
+        {
+            // v1.20+
+            version (Windows)
+                run("SET DMD="~hostDMD~" && "~hostDMD~" -run build.d -O -w -m"~bitsStr);
+            else
+                run("DMD="~hostDMD~" "~hostDMD~" -run build.d -O -w -m"~bitsStr);
+        }
         else
-            run("DMD="~hostDMD~" ./build.sh -m"~bitsStr);
+        {
+            version (Windows)
+                run("SET DC="~hostDMD~" && build.cmd -m"~bitsStr); // TODO: replace DC with DMD
+            else
+                run("DMD="~hostDMD~" ./build.sh -m"~bitsStr);
+        }
         rename(cloneDir~"/dub/bin/dub"~exe, cloneDir~"/dub/bin/dub"~bitsStr~exe);
     }
 }


### PR DESCRIPTION
I suspect that this isn't done deliberately, as no other tools have debug information compiled in.

The Windows build shrinks from almost 11 MB to about 3 MB. The linux binary will probably have even more debug info (binary size is currently 20 MB compared to other tools at 2-4 MB).