### PR TITLE
remove windbg from installation

### DIFF
--- a/create_dmd_release/build_all.d
+++ b/create_dmd_release/build_all.d
@@ -275,9 +275,7 @@ void prepareExtraBins(string workDir)
 {
     auto extraBins = [
         windows_both : [
-            "windbg.hlp", "lib.exe", "optlink.exe", "make.exe",
-            "replace.exe", "shell.exe", "windbg.exe", "dm.dll", "eecxxx86.dll",
-            "emx86.dll", "mspdb41.dll", "shcv.dll", "tlloc.dll"
+            "lib.exe", "optlink.exe", "make.exe", "replace.exe", "shell.exe"
         ].addPrefix("bin/").array,
         linux_both : ["bin32/dumpobj", "bin64/dumpobj", "bin32/obj2asm", "bin64/obj2asm"],
         freebsd_32 : ["bin32/dumpobj", "bin32/obj2asm", "bin32/shell"],


### PR DESCRIPTION
it's an embarrassment to have this 24 years old version still distributed.

https://dlang.org/windbg.html should be removed, too. It doesn't seem to be referenced from anywhere else but the sitemap. https://dlang.org/dmd-windows.html contains a reference to https://digitalmars.com/d/2.0/windbg.html, though, the D language site from 2011!