### PR TITLE
build dmd.exe with LDC

### DIFF
--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -419,8 +419,8 @@ void buildAll(Bits bits, string branch, bool dmdOnly=false)
         }
         else
         {
-            msvcEnv =
-                " " ~ quote("AR="     ~ dirName(hostDMD)~"/lib");
+            if (!hostDMD.endsWith("ldmd2") && !hostDMD.endsWith("ldmd2.exe"))
+                msvcEnv = " " ~ quote("AR="~dirName(hostDMD)~"/lib");
         }
     }
 

--- a/windows/build_release.bat
+++ b/windows/build_release.bat
@@ -14,6 +14,10 @@ set VCDIR=%VCToolsInstallDir%
 set SDKDIR=.
 set MSVC_AR=%VCToolsInstallDir%\bin\Hostx64\x64\lib.exe
 
+rem enable autodetection in LDC, so it doesn't mix x86/x64 libs
+set LDC_VSDIR=%VSINSTALLDIR%
+set VSINSTALLDIR=
+
 cd create_dmd_release
 
 "%HOST_DC%" -m32 -gf build_all.d common.d -version=NoVagrant || exit /B 1


### PR DESCRIPTION
What's not optimal is that the LDC-built version gets only limited coverage in the dmd tests, only the win32-ldc pipeline.