### PR TITLE
README.TXT: remove windbg, add missing tools

### DIFF
--- a/create_dmd_release/extras/windows/dmd2/windows/bin/README.TXT
+++ b/create_dmd_release/extras/windows/dmd2/windows/bin/README.TXT
@@ -4,22 +4,14 @@ Win32 files
 
 dmd.exe		D compiler			http://dlang.org/dmd-windows.html
 sc.ini		D compiler configuration file	http://dlang.org/dmd-windows.html#sc_ini
-shell.exe	Test script runner		http://www.digitalmars.com/ctg/shell.html
-rdmd.exe	Run D program as a script	http://dlang.org/rdmd.html
+ddemangle.exe	D symbol demangler
+dub.exe		D's package manager		https://github.com/dlang/dub
+dustmite.exe	D source code minimizer		https://github.com/CyberShadow/DustMite
 lib.exe		Librarian			http://www.digitalmars.com/ctg/lib.html
-link.exe	Linker				http://www.digitalmars.com/ctg/optlink.html
+libcurl.dll	Curl Library			https://curl.haxx.se/
+lld-link.exe	LLVM Linker			https://lld.llvm.org/
 make.exe	Make program			http://www.digitalmars.com/ctg/make.html
+optlink.exe	Linker				http://www.digitalmars.com/ctg/optlink.html
+rdmd.exe	Run D program as a script	http://dlang.org/rdmd.html
 replace.exe	Find/replace text in file(s)
-
-Win32 debugger
---------------
-windbg.exe	Microsoft debugger		http://www.digitalmars.com/d/2.0/windbg.html
-shcv.dll	For windbg.exe (symbol manipulator)
-tlloc.dll	For windbg.exe (local transport layer for debugger)
-dm.dll		For windbg.exe
-emx86.dll	For windbg.exe
-eecxxx86.dll	For windbg.exe (C++ expression evaluator)
-mspdb41.dll	For windbg.exe (reads PDB debug info)
-windbg.hlp	Help file for Microsoft debugger
-
-
+shell.exe	Test script runner		http://www.digitalmars.com/ctg/shell.html


### PR DESCRIPTION
This file uses tabs which seems to make the diff look weird. The normal file view has all columns aligned.