### PR TITLE
MinGW-based libs: Add wide entry points

### DIFF
--- a/windows/build_mingw.bat
+++ b/windows/build_mingw.bat
@@ -3,11 +3,13 @@
 set ROOT=%CD%
 mkdir "%ROOT%\artifacts"
 
-set ARTIFACT=mingw-libs-%MINGW_VER%-2.zip
+set TAG=mingw-libs-%MINGW_VER%-2
+set ARTIFACT=%TAG%.zip
 set ARTIFACTPATH=%ROOT%\artifacts\%ARTIFACT%
+set GITHUB_RELEASE=https://github.com/dlang/installer/releases/download/%TAG%/%ARTIFACT%
 
 REM Stop early if the artifact already exists
-powershell -Command "Invoke-WebRequest downloads.dlang.org/other/%ARTIFACT% -OutFile %ARTIFACTPATH%" && exit /B 0
+powershell -Command "Invoke-WebRequest %GITHUB_RELEASE% -OutFile %ARTIFACTPATH%" && exit /B 0
 
 set DMD_URL=http://downloads.dlang.org/releases/2.x/%D_VERSION%/dmd.%D_VERSION%.windows.7z
 echo DMD_URL=%DMD_URL%

--- a/windows/build_mingw.bat
+++ b/windows/build_mingw.bat
@@ -3,8 +3,11 @@
 set ROOT=%CD%
 mkdir "%ROOT%\artifacts"
 
+set ARTIFACT=mingw-libs-%MINGW_VER%-2.zip
+set ARTIFACTPATH=%ROOT%\artifacts\%ARTIFACT%
+
 REM Stop early if the artifact already exists
-powershell -Command "Invoke-WebRequest downloads.dlang.org/other/mingw-libs-%MINGW_VER%.zip -OutFile %ROOT%\artifacts\mingw-libs-%MINGW_VER%.zip" && exit /B 0
+powershell -Command "Invoke-WebRequest downloads.dlang.org/other/%ARTIFACT% -OutFile %ARTIFACTPATH%" && exit /B 0
 
 set DMD_URL=http://downloads.dlang.org/releases/2.x/%D_VERSION%/dmd.%D_VERSION%.windows.7z
 echo DMD_URL=%DMD_URL%
@@ -35,4 +38,4 @@ call "%VSINSTALLDIR%\VC\Auxiliary\Build\vcvarsall.bat" x86
 cd %ROOT%\windows\mingw
 dmd -run buildsdk.d x86 %ROOT%\mingw-w64 dmd2\windows\lib32mscoff\mingw || exit /B 1
 
-7z a %ROOT%\artifacts\mingw-libs-%MINGW_VER%.zip dmd2\windows
+7z a "%ARTIFACTPATH%" dmd2\windows

--- a/windows/mingw/buildsdk.d
+++ b/windows/mingw/buildsdk.d
@@ -379,6 +379,8 @@ void buildMsvcrt(string outDir)
         // compile some additional objects
         foreach (i; 0 .. 3)
             addObj(format!"msvcrt_stub%d.obj"(i), format!"/D_APPTYPE=%d msvcrt_stub.c"(i));
+        foreach (i; 1 .. 3) // not needed for DLLs
+            addObj(format!"msvcrt_stub_wide%d.obj"(i), format!"/D_APPTYPE=%d /D_UNICODE msvcrt_stub.c"(i));
         addObj("msvcrt_data.obj", "msvcrt_data.c");
         addObj("msvcrt_atexit.obj", "msvcrt_atexit.c");
         if (!x64)


### PR DESCRIPTION
So that the user/druntime can use the wide `wmain` / `wWinMain` C entry points too.