### PR TITLE
Windows installer: increase compressor dictionary size for smaller installer

### DIFF
--- a/windows/d2-installer.nsi
+++ b/windows/d2-installer.nsi
@@ -135,7 +135,7 @@ InstallDirRegKey HKCU "Software\${DName}" "InstallationFolder"
 CRCCheck force
 
 SetCompressor /SOLID lzma
-
+SetCompressorDictSize 112
 
 ;------------------------------------------------------------
 ; Macros definition


### PR DESCRIPTION
This reduces the size of the installer from 26 MB to 24 MB.