### PR TITLE
update to MSVC BuildTools 2017

### DIFF
--- a/create_dmd_release/build_all.d
+++ b/create_dmd_release/build_all.d
@@ -318,7 +318,7 @@ void runBuild(ref Box box, string ver, bool isBranch, bool skipDocs)
                 dmd = `old-dmd\dmd2\windows\bin\dmd.exe`;
             else
                 dmd = `ldc\ldc2-`~ldcVer~`-windows-multilib\bin\ldmd2.exe`;
-            rdmd = `old-dmd\dmd2\windows\bin\rdmd.exe --compiler=`~dmd;
+            rdmd = `old-dmd\dmd2\windows\bin\rdmd.exe`;
             break;
         case OS.osx:
             dmd = "old-dmd/dmd2/osx/bin/dmd";
@@ -326,7 +326,7 @@ void runBuild(ref Box box, string ver, bool isBranch, bool skipDocs)
             break;
         }
 
-        auto build = rdmd~" create_dmd_release --extras=extraBins --use-clone=clones --host-dmd="~dmd;
+        auto build = rdmd~" -g create_dmd_release --extras=extraBins --use-clone=clones --host-dmd="~dmd;
         if (box.model != Model._both)
             build ~= " --only-" ~ box.modelS;
         if (skipDocs)

--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -463,7 +463,6 @@ void buildAll(Bits bits, string branch, bool dmdOnly=false)
 
     version (Windows) if (bits == Bits.bits64)
     {
-        msvcEnv ~= " "~quote("CC32=" ~ msvcBin32Dir~"/cl");
         info("Building Druntime 32mscoff");
         changeDir(cloneDir~"/druntime");
         run(msvcVarsX86~makecmd~msvcEnv~" druntime32mscoff");

--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -9,12 +9,10 @@ Prerequisites to Run:
 - Posix: Working gcc toolchain, including GNU make which is not installed on
   FreeBSD by default. On OSX, you can install the gcc toolchain through Xcode.
 - Windows: Working DMC and MSVC toolchains. The default make must be DM make.
-  Also, these environment variables must be set:
-    VCDIR:  Visual C directory
-    SDKDIR: Windows SDK directory
+  Also, this environment variable must be set:
+    VSINSTALLDIR:  Visual C directory
   Examples:
-    set VCDIR=C:\Program Files (x86)\Microsoft Visual Studio 8\VC\
-    set SDKDIR=C:\Program Files\Microsoft SDKs\Windows\v7.1\
+    set VSINSTALLDIR="C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\"
 - Windows: A version of OPTLINK with the /LA[RGEADDRESSAWARE] flag:
     <https://github.com/DigitalMars/optlink/commit/475bc5c1fa28eaf899ba4ac1dcfe2ab415db16c6>
 - Windows: Microsoft's HTML Help Workshop on the PATH.
@@ -164,12 +162,6 @@ bool do32Bit;
 bool do64Bit;
 bool codesign;
 
-version(Windows)
-{
-    string msvcBin32Dir;
-    string msvcBin64Dir;
-}
-
 // These are absolute and do NOT contain a trailing slash:
 string defaultWorkDir;
 string cloneDir;
@@ -184,8 +176,6 @@ string allExtrasDir;
 string osExtrasDir;
 string customExtrasDir;
 string hostDMD;
-string win64vcDir;
-string win64sdkDir;
 
 int main(string[] args)
 {
@@ -304,39 +294,6 @@ void init(string branch)
     releaseLib64Dir = osDir ~ "/lib" ~ suffix64;
     allExtrasDir = cloneDir ~ "/installer/create_dmd_release/extras/all";
     osExtrasDir  = cloneDir ~ "/installer/create_dmd_release/extras/" ~ osDirName;
-
-    // configure MSVC tools needed for 64-bit
-    version (Windows) if (do64Bit)
-    {
-        if(environment.get("VCDIR", "") == "" || environment.get("SDKDIR", "") == "")
-        {
-            fail(`
-                    Environment variables VCDIR and SDKDIR must both be set. For example:
-                    set VCDIR=C:\Program Files (x86)\Microsoft Visual Studio 8\VC\
-                    set SDKDIR=C:\Program Files\Microsoft SDKs\Windows\v7.1\
-                `.outdent().strip());
-        }
-
-        win64vcDir  = environment[ "VCDIR"].chomp("\\").chomp("/");
-        win64sdkDir = environment["SDKDIR"].chomp("\\").chomp("/");
-
-        trace("VCDIR:  " ~ displayPath(win64vcDir));
-        trace("SDKDIR: " ~ displayPath(win64sdkDir));
-
-        msvcBin64Dir = win64vcDir ~ "/bin/x86_amd64";
-        if(!exists(msvcBin64Dir~"/cl.exe"))
-            msvcBin64Dir = win64vcDir ~ "/bin/amd64";
-        if(!exists(msvcBin64Dir~"/cl.exe"))
-            msvcBin64Dir = win64vcDir ~ "/bin/Hostx64/x64"; // VS2017+
-        if(!exists(msvcBin64Dir~"/cl.exe"))
-            fail(`Microsoft compiler cl.exe for 64-bit not found in ` ~ win64vcDir);
-
-        msvcBin32Dir = win64vcDir ~ "/bin";
-        if(!exists(msvcBin32Dir~"/cl.exe"))
-            msvcBin32Dir = win64vcDir ~ "/bin/Hostx86/x86"; // VS2017+
-        if(!exists(msvcBin32Dir~"/cl.exe"))
-            fail(`Microsoft compiler cl.exe for 32-bit not found in ` ~ win64vcDir);
-    }
 }
 
 void cleanAll(string branch)
@@ -405,17 +362,19 @@ void buildAll(Bits bits, string branch, bool dmdOnly=false)
     auto saveDir = getcwd();
     scope(exit) changeDir(saveDir);
 
+    auto msvcVarsX64 = "";
+    auto msvcVarsX86 = "";
     auto msvcEnv = "";
     version(Windows)
     {
         if(bits == Bits.bits64)
         {
-            msvcEnv =
-                " " ~ quote("VCDIR="  ~ win64vcDir) ~
-                " " ~ quote("SDKDIR=" ~ win64sdkDir) ~
-                " " ~ quote("CC="     ~ msvcBin64Dir~"/cl") ~
-                " " ~ quote("LD="     ~ msvcBin64Dir~"/link") ~
-                " " ~ quote("AR="     ~ msvcBin64Dir~"/lib");
+            // Just overwrite any logic in makefiles and leave setup to vcvarsall.bat
+            msvcEnv = ` "VCDIR=" "SDKDIR=" "CC=cl" "CC32=cl" "LD=link" "AR=lib"`;
+            // Setup MSVC environment for x64 native builds
+            auto msvcVars = quote(environment["VSINSTALLDIR"] ~ `VC\Auxiliary\Build\vcvarsall.bat`);
+            msvcVarsX64 = msvcVars~" x64 && ";
+            msvcVarsX86 = msvcVars~" x86 && ";
         }
         else
         {
@@ -486,13 +445,13 @@ void buildAll(Bits bits, string branch, bool dmdOnly=false)
 
     info("Building Druntime "~bitsDisplay);
     changeDir(cloneDir~"/druntime");
-    run(makecmd~pic~msvcEnv~makeTargetDruntime);
+    run(msvcVarsX64~makecmd~pic~msvcEnv~makeTargetDruntime);
     removeFiles(cloneDir~"/druntime", "*{"~obj~"}", SpanMode.depth,
         file => !file.baseName.startsWith("minit"));
 
     info("Building Phobos "~bitsDisplay);
     changeDir(cloneDir~"/phobos");
-    run(makecmd~pic~msvcEnv);
+    run(msvcVarsX64~makecmd~pic~msvcEnv);
 
     version(OSX) if(bits == Bits.bits64)
     {
@@ -507,13 +466,13 @@ void buildAll(Bits bits, string branch, bool dmdOnly=false)
         msvcEnv ~= " "~quote("CC32=" ~ msvcBin32Dir~"/cl");
         info("Building Druntime 32mscoff");
         changeDir(cloneDir~"/druntime");
-        run(makecmd~msvcEnv~" druntime32mscoff");
+        run(msvcVarsX86~makecmd~msvcEnv~" druntime32mscoff");
         removeFiles(cloneDir~"/druntime", "*{"~obj~"}", SpanMode.depth,
                     file => !file.baseName.startsWith("minit"));
 
         info("Building Phobos 32mscoff");
         changeDir(cloneDir~"/phobos");
-        run(makecmd~msvcEnv~" phobos32mscoff");
+        run(msvcVarsX86~makecmd~msvcEnv~" phobos32mscoff");
         removeFiles(cloneDir~"/phobos", "*{"~obj~"}", SpanMode.depth);
     }
 

--- a/windows/build_release.bat
+++ b/windows/build_release.bat
@@ -12,11 +12,6 @@ set HOST_DC=%DMD_BIN_DIR%\dmd.exe
 set PATH=%DMD_BIN_DIR%;%PATH%;%CD%\dm\bin
 set VCDIR=%VCToolsInstallDir%
 set SDKDIR=.
-set MSVC_AR=%VCToolsInstallDir%\bin\Hostx64\x64\lib.exe
-
-rem enable autodetection in LDC, so it doesn't mix x86/x64 libs
-set LDC_VSDIR=%VSINSTALLDIR%
-set VSINSTALLDIR=
 
 cd create_dmd_release
 


### PR DESCRIPTION
- use vcvarsall.bat to setup correct compiler environment
  (rather than explicitly including things)
- set CC, AR, LIB, and CC32 to plain command names
  (leaving it to vcvarsall.bat to resolve them)
- BuildTools 2019 would fail to execute on Windows 7
  (might miss some updates)