### PR TITLE
fix NSIS installer warnings

### DIFF
--- a/windows/d2-installer-descriptions.nsh
+++ b/windows/d2-installer-descriptions.nsh
@@ -9,7 +9,6 @@ LangString DESC_AddD2ToPath ${LANG_ENGLISH} "Modify the PATH environment variabl
 
 LangString DESC_VisualDDownload ${LANG_ENGLISH} "Visual Studio package providing both project management and language services. It works with Visual Studio 2008-2017 (and the free VS Shells)"
 LangString DESC_DmcDownload ${LANG_ENGLISH} "Digital Mars C/C++ compiler"
-LangString DESC_Dmd1Download ${LANG_ENGLISH} "Digital Mars D version 1 compiler (discontinued)"
 
 
 ; Shortcuts
@@ -25,5 +24,4 @@ LangString SHORTCUT_Uninstall ${LANG_ENGLISH} "Uninstall"
     !insertmacro MUI_DESCRIPTION_TEXT ${AddD2ToPath} $(DESC_AddD2ToPath)
     !insertmacro MUI_DESCRIPTION_TEXT ${VisualDDownload} $(DESC_VisualDDownload)
     !insertmacro MUI_DESCRIPTION_TEXT ${DmcDownload} $(DESC_DmcDownload)
-    !insertmacro MUI_DESCRIPTION_TEXT ${Dmd1Download} $(DESC_Dmd1Download)
 !insertmacro MUI_FUNCTION_DESCRIPTION_END

--- a/windows/d2-installer.nsi
+++ b/windows/d2-installer.nsi
@@ -122,6 +122,8 @@ Var VCPath
 ; General definitions
 ;--------------------------------------------------------
 
+Unicode True
+
 ; Name of the installer
 Name "D Programming Language"
 

--- a/windows/d2-installer.nsi
+++ b/windows/d2-installer.nsi
@@ -95,6 +95,7 @@
   !define /file Version2 ${D2VersionPath}
 !endif
 
+Unicode True
 
 ;--------------------------------------------------------
 ; Includes
@@ -121,8 +122,6 @@ Var VCPath
 ;--------------------------------------------------------
 ; General definitions
 ;--------------------------------------------------------
-
-Unicode True
 
 ; Name of the installer
 Name "D Programming Language"


### PR DESCRIPTION
- remove description for dropped dmd1 download section
- build unicode instead of deprecated ansi installer