### PR TITLE
Windows: add 64-bit build of dub.exe

### DIFF
--- a/changelog/windows.dd
+++ b/changelog/windows.dd
@@ -2,10 +2,10 @@ The Windows installation has received a couple of updates
 
 - the released dmd.exe is now built with LDC for a reduction of compilation
   times of 30-40%.
-- 64-bit builds of dmd.exe and lld-link.exe have been added to the bin64 folder
+- 64-bit builds of dmd.exe, dub.exe and lld-link.exe have been added to the bin64 folder
 - The bundled Windows libraries and definitions have been changed from MinGW 5.0.2
   to MinGW 7.0.0 (with additional wide string `main` entrypoints).
-- The bundled LLD linker on Windows binaries have been upgraded to 9.0.0 (including a
+- The bundled LLD linker on Windows has been upgraded to 9.0.0 (including a
   patch that allows exceptions to work on Win32).
 - The VC runtime linked with the MinGW import libraries has been upgraded to
   msvcr120.dll (the last version that allows simple copying and no dependency

--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -506,7 +506,11 @@ void buildAll(Bits bits, string branch, bool dmdOnly=false)
         run(makecmd~" dustmite");
 
         removeFiles(cloneDir~"/tools", "*.{"~obj~"}", SpanMode.depth);
+    }
 
+    bool buildDub = true; // build64BitTools || bits == Bits.bits32;
+    if(buildDub)
+    {
         // build dub with stable (host) compiler, b/c it breaks
         // too easily with the latest compiler, e.g. for nightlies
         info("Building Dub "~bitsDisplay);
@@ -650,8 +654,8 @@ void createRelease(string branch)
         else // Win doesn't include 64-bit tools
         {
             copyDir(cloneDir~"/tools/generated/"~osDirName~"/64", releaseBin64Dir, file => !file.endsWith(obj));
-            copyFile(cloneDir~"/dub/bin/dub64"~exe, releaseBin64Dir~"/dub"~exe);
         }
+        copyFile(cloneDir~"/dub/bin/dub64"~exe, releaseBin64Dir~"/dub"~exe);
         if (codesign)
             signBinaries(releaseBin64Dir);
     }


### PR DESCRIPTION
otherwise, dub never uses the 64-bit version of dmd, even if first on the PATH.