### PR TITLE
remove broken and unmaintained OSX-32 builds from releases

### DIFF
--- a/create_dmd_release/build_all.d
+++ b/create_dmd_release/build_all.d
@@ -37,7 +37,7 @@ enum linux_both = Platform(OS.linux, Model._both);
 
 /// Name: create_dmd_release-osx
 /// Setup: Preparing OSX-10.8 box, https://gist.github.com/MartinNowak/8156507
-enum osx_both = Platform(OS.osx, Model._both);
+enum osx_64 = Platform(OS.osx, Model._64);
 
 /// Name: create_dmd_release-windows
 /// Setup: Preparing Win7x64 box, https://gist.github.com/MartinNowak/8270666
@@ -46,7 +46,7 @@ enum windows_both = Platform(OS.windows, Model._both);
 version(Windows)
     enum platforms = [windows_both];
 else
-    enum platforms = [linux_both, windows_both, osx_both, freebsd_32, freebsd_64];
+    enum platforms = [linux_both, windows_both, osx_64, freebsd_32, freebsd_64];
 
 /// the LDC version to use to build dmd (on Windows), leave empty to use dmd
 enum ldcVer = "1.21.0";
@@ -57,7 +57,11 @@ struct Platform
 {
     @property string osS() { return to!string(os); }
     @property string modelS() { return model == Model._both ? "" : to!string(cast(uint)model); }
-    string toString() { return model == Model._both ? osS : osS ~ "-" ~ modelS; }
+    string toString()
+    {
+        // 64-bit builds on OSX named just "osx" for compat with older universal binary releases
+        return (model == Model._both || os == OS.osx) ? osS : osS ~ "-" ~ modelS;
+    }
     OS os;
     Model model;
 }
@@ -277,7 +281,7 @@ void prepareExtraBins(string workDir)
         linux_both : ["bin32/dumpobj", "bin64/dumpobj", "bin32/obj2asm", "bin64/obj2asm"],
         freebsd_32 : ["bin32/dumpobj", "bin32/obj2asm", "bin32/shell"],
         freebsd_64 : [],
-        osx_both : ["bin/dumpobj", "bin/obj2asm", "bin/shell"],
+        osx_64 : ["bin/dumpobj", "bin/obj2asm", "bin/shell"],
     ];
 
     foreach (platform; platforms)

--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -218,9 +218,9 @@ int main(string[] args)
 
     version(OSX)
     {
-        if(do32Bit || do64Bit)
+        if(do32Bit)
         {
-            info("WARNING: Using --only-32 and --only-64: Universal binaries will not be created.");
+            fatal("32-bit builds no longer supported on OSX.");
             return 1;
         }
     }
@@ -461,13 +461,6 @@ void buildAll(Bits bits, string branch, bool dmdOnly=false)
     info("Building Phobos "~bitsDisplay);
     changeDir(cloneDir~"/phobos");
     run(msvcVars~makecmd~pic~msvcEnv);
-
-    version(OSX) if(bits == Bits.bits64)
-    {
-        info("Building Phobos Universal Binary");
-        changeDir(cloneDir~"/phobos");
-        run(makecmd~" libphobos2.a");
-    }
     removeFiles(cloneDir~"/phobos", "*{"~obj~"}", SpanMode.depth);
 
     version (Windows) if (bits == Bits.bits64)
@@ -588,14 +581,7 @@ void createRelease(string branch)
 
     // Copy lib
     version(OSX)
-    {
-        if(do32Bit && do64Bit)
-            copyFile(cloneDir~"/phobos/generated/"~osDirName~"/release/libphobos2.a", releaseLib32Dir~"/libphobos2.a");
-        else if(do32Bit)
-            copyFile(cloneDir~"/phobos/generated/"~osDirName~"/release/32/libphobos2.a", releaseLib32Dir~"/libphobos2_32.a");
-        else if(do64Bit)
-            copyFile(cloneDir~"/phobos/generated/"~osDirName~"/release/64/libphobos2.a", releaseLib32Dir~"/libphobos2_64.a");
-    }
+        copyFile(cloneDir~"/phobos/generated/"~osDirName~"/release/64/libphobos2.a", releaseLib32Dir~"/libphobos2.a");
     else version (Windows)
     {
         if(do32Bit)
@@ -727,13 +713,21 @@ string quote(string str)
 
 string releaseBitSuffix(bool has32, bool has64)
 {
-    if(do32Bit && !do64Bit)
-        return releaseBitSuffix32;
+    version (OSX)
+    {
+        assert(!do32Bit && do64Bit);
+        return "";
+    }
+    else
+    {
+        if(do32Bit && !do64Bit)
+            return releaseBitSuffix32;
 
-    if(do64Bit && !do32Bit)
-        return releaseBitSuffix64;
+        if(do64Bit && !do32Bit)
+            return releaseBitSuffix64;
 
-    return "";
+        return "";
+    }
 }
 
 // Filesystem Utils -----------------------


### PR DESCRIPTION
Would no longer build due to changes in druntime mach-o headers.
Hasn't been tested since quite a while and is officially no longer supported anyhow ([Change Log: 2.085.0 - D Programming Language](https://dlang.org/changelog/2.085.0.html#osx-32bit)).