### PR TITLE
Make the activate generated script reentrant

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -903,7 +903,7 @@ write_env_vars() {
     echo "    unset -f deactivate"
     echo "}"
     echo
-    echo "[[ -v _OLD_D_PATH ]] && deactivate"
+    echo "if [ -v _OLD_D_PATH ] ; then deactivate; fi"
     echo "_OLD_D_PATH=\"\${PATH:-}\""
 
     if [ -n "$libpath" ] ; then

--- a/script/install.sh
+++ b/script/install.sh
@@ -903,6 +903,7 @@ write_env_vars() {
     echo "    unset -f deactivate"
     echo "}"
     echo
+    echo "[[ -v _OLD_D_PATH ]] && deactivate"
     echo "_OLD_D_PATH=\"\${PATH:-}\""
 
     if [ -n "$libpath" ] ; then


### PR DESCRIPTION
Currently sourcing `activate` several times in a row (either for the same version or different versions) messes things up. With this the `deactivate` function clears the current activation before entering the new one.