### PR TITLE
Fixes issue 21059: installer fails when piped on Posix.

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -9,9 +9,11 @@ _() {
 
 # Returns false if the script is invoked from a Windows command prompt.
 posix_terminal() {
-    # If this script is run on Windows cmd by passing it as argument to bash.exe,
-    # the shell level will be 1. If it is run from a POSIX terminal, it will be > 1.
-    if [ "$SHLVL" = 1 ]; then
+    # If run from a POSIX terminal (including under MSYS2 or Cygwin) the TERM
+    # variable is defined to something like "xterm". If run from a Windows
+    # command prompt through bash.exe from an MSYS installation, TERM keeps
+    # its default value, which is "cygwin".
+    if [[ $TERM == "cygwin" ]]; then
         false
     else
         true

--- a/script/install.sh
+++ b/script/install.sh
@@ -13,7 +13,7 @@ posix_terminal() {
     # variable is defined to something like "xterm". If run from a Windows
     # command prompt through bash.exe from an MSYS installation, TERM keeps
     # its default value, which is "cygwin".
-    if [[ $TERM == "cygwin" ]]; then
+    if [[ "${TERM:-noterm}" == "cygwin" ]]; then
         false
     else
         true


### PR DESCRIPTION
The assumption that $SHLVL increases when the script is run does not always hold. $SHLVL does not increase if the script is piped into bash, thereby failing to detect Posix. Also, if the default terminal shell is not bash, $SHLVL might be 1 on Posix.