### PR TITLE
Fix wrong deactivation in chained activation

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -886,6 +886,9 @@ write_env_vars() {
 
     logV "Writing environment variables to $ROOT/$1/activate"
 {
+    # when activate is called twice, deactivate the prior context first
+    echo "if [ ! -z \${_OLD_D_PATH+x} ] ; then deactivate; fi"
+    echo
     echo "deactivate() {"
     echo "    export PATH=\"\$_OLD_D_PATH\""
     if [ -n "$libpath" ] ; then
@@ -905,7 +908,6 @@ write_env_vars() {
     echo "    unset -f deactivate"
     echo "}"
     echo
-    echo "if [ -v _OLD_D_PATH ] ; then deactivate; fi"
     echo "_OLD_D_PATH=\"\${PATH:-}\""
 
     if [ -n "$libpath" ] ; then

--- a/test/t/double_install.sh
+++ b/test/t/double_install.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -uexo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/../
+. $DIR/common.sh
+
+priorDMD=$(dmd --version || echo "no dmd")
+
+. $(./script/install.sh install dmd-2.082.1 -a)
+test "$(dmd --version | grep -oE '[^ ]+$' | head -n1 | tr -d '\r')" = "v2.082.1"
+
+. $(./script/install.sh install dmd-2.083.1 -a)
+test "$(dmd --version | grep -oE '[^ ]+$' | head -n1 | tr -d '\r')" = "v2.083.1"
+
+deactivate
+
+test "$(dmd --version || echo "no dmd")" = "$priorDMD"


### PR DESCRIPTION
`deactivate` for the previous installation was called after the new
deactivation handler has been registered.