### PR TITLE
build binary releases with LDC

### DIFF
--- a/.azure-pipelines/build-winrelease.yml
+++ b/.azure-pipelines/build-winrelease.yml
@@ -27,7 +27,12 @@ steps:
       @echo on
       powershell -command "& { iwr https://dlang.org/d-keyring.gpg -OutFile d-keyring.gpg }"
       gpg --import d-keyring.gpg
-      call windows/build_release.bat
+      set PATH=%CD%\dm\bin;%PATH%
+      set LDC_VSDIR_FORCE=1
+      cd create_dmd_release
+      ..\ldc2\bin\ldmd2 -g build_all.d common.d -version=NoVagrant || exit /B 1
+      copy ..\ldc2\bin\libcurl.dll .
+      build_all v%HOST_LDC_VERSION% %BRANCH% || exit /B 1
     displayName: Build release
   - script: |
       7z x create_dmd_release\build\dmd.$(BRANCH).windows.zip -odmd.$(BRANCH).windows

--- a/.azure-pipelines/build-winrelease.yml
+++ b/.azure-pipelines/build-winrelease.yml
@@ -16,8 +16,6 @@ steps:
       7z x dmc.zip
       powershell -command "& { iwr http://ftp.digitalmars.com/bup.zip -OutFile bup.zip }"
       7z x bup.zip dm/bin/implib.exe
-      powershell -command "& { iwr https://www.7-zip.org/a/7z1900-extra.7z -OutFile 7za.7z }"
-      7z e 7za.7z 7za.exe -odmd2\windows\bin
       powershell -command "& { iwr https://nsis.sourceforge.io/mediawiki/images/c/c9/Inetc.zip -OutFile inetc.zip }"
       7z x inetc.zip -y -bb1 "-oc:\Program Files (x86)\NSIS"
     displayName: Install prerequisites

--- a/.azure-pipelines/build-winrelease.yml
+++ b/.azure-pipelines/build-winrelease.yml
@@ -9,10 +9,11 @@ steps:
   - download: current
     artifact: docs
   - script: |
-      powershell -command "& { iwr http://downloads.dlang.org/releases/2.x/$(HOST_DMD_VERSION)/dmd.$(HOST_DMD_VERSION).windows.7z -OutFile dmd2.7z }"
-      7z x dmd2.7z
-      powershell -command "& { iwr http://downloads.dlang.org/other/dm857c.zip -OutFile dmc.7z }"
-      7z x dmc.7z
+      powershell -command "& { iwr https://github.com/ldc-developers/ldc/releases/download/v$(HOST_LDC_VERSION)/ldc2-$(HOST_LDC_VERSION)-windows-multilib.7z -OutFile ldc.7z }"
+      7z x ldc.7z
+      move ldc2-$(HOST_LDC_VERSION)-windows-multilib ldc2
+      powershell -command "& { iwr http://downloads.dlang.org/other/dm857c.zip -OutFile dmc.zip }"
+      7z x dmc.zip
       powershell -command "& { iwr http://ftp.digitalmars.com/bup.zip -OutFile bup.zip }"
       7z x bup.zip dm/bin/implib.exe
       powershell -command "& { iwr https://www.7-zip.org/a/7z1900-extra.7z -OutFile 7za.7z }"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,6 +71,6 @@ jobs:
       vmImage: 'vs2017-win2016'
     variables:
       VSINSTALLDIR: C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\
-      HOST_DMD_VERSION: 2.088.0
+      HOST_LDC_VERSION: 1.23.0
     steps:
       - template: .azure-pipelines/build-winrelease.yml

--- a/changelog/ldc_built_releases.md
+++ b/changelog/ldc_built_releases.md
@@ -1,0 +1,13 @@
+DMD binary releases are now built with LDC
+
+Binary releases for Linux, OSX, and FreeBSD are now built with
+LDC. This follows the switch to LDC as host compiler for Windows
+releases with 2.091.0.
+
+Building DMD with LDC should provide a significant speedup of the compiler (20-30%).
+
+This change comes with the following limitations:
+- no more FreeBSD 32-bit binary releases (no 32-bit LDC host compiler)
+- additional binary tools copied over from previous dmd releases are no longer included
+  (see [c0de0295e6b1f9a802bb04a97cca9f06c5b0dccd](https://github.com/dlang/installer/commit/c0de0295e6b1f9a802bb04a97cca9f06c5b0dccd) (optlink still included))
+  They are still available via https://digitalmars.com/ or from older dmd releases.

--- a/create_dmd_release/build_all.d
+++ b/create_dmd_release/build_all.d
@@ -270,26 +270,6 @@ auto addPrefix(R)(R rng, string prefix)
 }
 
 //------------------------------------------------------------------------------
-// Copy additional release binaries from the previous release
-
-void prepareExtraBins(string workDir)
-{
-    auto extraBins = [
-        windows_both : [
-            "lib.exe", "optlink.exe", "make.exe", "replace.exe", "shell.exe"
-        ].addPrefix("bin/").array,
-        linux_both : ["bin32/dumpobj", "bin64/dumpobj", "bin32/obj2asm", "bin64/obj2asm"],
-        freebsd_32 : ["bin32/dumpobj", "bin32/obj2asm", "bin32/shell"],
-        freebsd_64 : [],
-        osx_64 : ["bin/dumpobj", "bin/obj2asm", "bin/shell"],
-    ];
-
-    foreach (platform; platforms)
-        copyFiles(extraBins[platform].addPrefix("dmd2/"~platform.osS~"/").array(),
-                  workDir~"/"~platform.toString~"/old-dmd", workDir~"/"~platform.osS~"/extraBins");
-}
-
-//------------------------------------------------------------------------------
 // builds a dmd.VERSION.OS.MODEL.zip on the vanilla VirtualBox image
 
 void runBuild(ref Box box, string ver, bool isBranch, bool skipDocs)
@@ -599,8 +579,6 @@ int main(string[] args)
     }
     applyPatches(gitTag, skipDocs, workDir~"/clones");
 
-    // copy weird custom binaries from the previous release
-    prepareExtraBins(workDir);
     // add latest optlink
     extract(cacheDir~"/"~optlink, workDir~"/windows/extraBins/dmd2/windows/bin/");
     if (exists(workDir~"/windows/extraBins/dmd2/windows/bin/link.exe"))

--- a/create_dmd_release/build_all.d
+++ b/create_dmd_release/build_all.d
@@ -308,10 +308,8 @@ void runBuild(ref Box box, string ver, bool isBranch, bool skipDocs)
             rdmd = "old-dmd/dmd2/linux/bin64/rdmd --compiler="~dmd;
             break;
         case OS.windows:
-            // copy libcurl needed for create_dmd_release and dlang.org
             cmd(`copy old-dmd\dmd2\windows\bin\libcurl.dll .`);
-            cmd(`copy old-dmd\dmd2\windows\bin\libcurl.dll clones\dlang.org`);
-            cmd(`copy old-dmd\dmd2\windows\lib\curl.lib clones\dlang.org`);
+            // copy libcurl needed for create_dmd_release
 
             if (ldcVer.empty)
                 dmd = `old-dmd\dmd2\windows\bin\dmd.exe`;

--- a/create_dmd_release/build_all.d
+++ b/create_dmd_release/build_all.d
@@ -281,6 +281,9 @@ void runBuild(ref Box box, string ver, bool isBranch, bool skipDocs, string ldcV
         case OS.windows:
             // copy libcurl needed for create_dmd_release
             cmd("copy ldc/ldc2-"~ldcVer~"-windows-multilib/bin/libcurl.dll .");
+            // force LDC to setup VC environment internally (despite VSINSTALLDIR)
+            // https://github.com/ldc-developers/ldc/blob/3f1a3e683a93e402997c21cbfd92fc1f2039ee89/driver/tool.cpp#L219-L226
+            cmd("$env:LDC_VSDIR_FORCE=1");
 
             dmd = "ldc/ldc2-"~ldcVer~"-windows-multilib/bin/ldmd2.exe";
             rdmd = "ldc/ldc2-"~ldcVer~"-windows-multilib/bin/rdmd.exe --compiler="~dmd;

--- a/create_dmd_release/build_all.d
+++ b/create_dmd_release/build_all.d
@@ -22,9 +22,8 @@ static assert(__VERSION__ >= 2067, "Requires dmd >= 2.067 with a fix for Bugzill
 enum freebsd_64 = Platform(OS.freebsd, Model._64);
 
 /// Name: create_dmd_release-linux
-/// VagrantBox.es: Opscode debian-7.4
-/// URL: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_debian-7.4_chef-provisionerless.box
-/// Setup: echo 'deb http://deb.debian.org/debian wheezy-backports main' | sudo tee -a /etc/apt/sources.list; sudo dpkg --add-architecture i386; sudo apt-get -y update; sudo apt-get -y -t wheezy-backports install git g++-multilib dpkg-dev rpm rsync unzip libcurl3 libcurl3:i386 --no-install-recommends; sudo apt-get clean
+/// https://vagrantcloud.com/debian/stretch64
+/// Setup: sudo dpkg --add-architecture i386; sudo apt-get -y update; sudo apt-get -y install git g++-multilib dpkg-dev rpm rsync unzip curl libcurl3 libcurl3:i386 --no-install-recommends; sudo apt-get clean
 enum linux_both = Platform(OS.linux, Model._both);
 
 /// OSes that require licenses must be setup manually

--- a/create_dmd_release/common.d
+++ b/create_dmd_release/common.d
@@ -287,7 +287,7 @@ void archiveLZMA(string inputDir, string archive)
     scope(exit) chdir(saveDir);
     chdir(dirName(inputDir));
 
-    auto cmd = archive.endsWith(".7z") ? ["7za", "a", archive, baseName(inputDir)] :
+    auto cmd = archive.endsWith(".7z") ? ["7z", "a", archive, baseName(inputDir)] :
             ["tar", "-Jcf", archive, baseName(inputDir)];
     auto rc = execute(cmd);
     enforce(!rc.status, rc.output);
@@ -306,7 +306,7 @@ void extract(string archive, string outputDir)
     else if (archive.endsWith(".tar.xz"))
         cmd = ["tar", "-C", outputDir, "-Jxf", archive];
     else if (archive.endsWith(".7z"))
-        cmd = ["7za", "x", "-o"~outputDir, archive];
+        cmd = ["7z", "x", "-o"~outputDir, archive];
     else
         assert(0, "Unsupported archive format "~archive~".");
 

--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -228,12 +228,7 @@ int main(string[] args)
     if(!do32Bit && !do64Bit)
         do32Bit = do64Bit = true;
 
-    if(customExtrasDir == "")
-    {
-        fatal("--extras=path is required.");
-        return 1;
-    }
-    else
+    if(customExtrasDir != "")
         customExtrasDir = customExtrasDir.absolutePath().chomp("\\").chomp("/");
 
     if(hostDMD == "")

--- a/windows/build_release.bat
+++ b/windows/build_release.bat
@@ -1,19 +1,13 @@
 setlocal
-call "%VSINSTALLDIR%\VC\Auxiliary\Build\vcvarsall.bat" x64
 echo on
 
 if "%BRANCH%" == "" set BRANCH=stable
-if "%HOST_DMD_VERSION%" == "" set HOST_DMD_VERSION=2.090.0
 
-rem to be run from installer root dir with dmd2 and dm folders
-set DMD_DIR=%CD%\dmd2
-set DMD_BIN_DIR=%DMD_DIR%\windows\bin
-set HOST_DC=%DMD_BIN_DIR%\dmd.exe
-set PATH=%DMD_BIN_DIR%;%PATH%;%CD%\dm\bin
-set VCDIR=%VCToolsInstallDir%
-set SDKDIR=.
+set HOST_DMD=%CD%\ldc2\bin\ldmd2.exe
+set PATH=%CD%\ldc2\bin;%CD%\dm\bin;%PATH%
 
+set LDC_VSDIR_FORCE=1
 cd create_dmd_release
 
-"%HOST_DC%" -m32 -gf build_all.d common.d -version=NoVagrant || exit /B 1
-build_all v%HOST_DMD_VERSION% %BRANCH% || exit /B 1
+"%HOST_DMD%" -gf build_all.d common.d -version=NoVagrant || exit /B 1
+build_all v%HOST_LDC_VERSION% %BRANCH% || exit /B 1


### PR DESCRIPTION
- curl no longer needed for dlang.org as docs are build on linux
- use current libcurl (the one to be released)
- drop custom binaries being copied from previous release
- use ldc to build release
- setup VC environment to build create_dmd_release on Windows
- update to debian 9 (stretch)
- add changelog entry
