### PR TITLE
Issue 21226 - Support installing older DMD versions

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -549,8 +549,10 @@ resolve_latest() {
             # dmd-nightly, dmd-master, dmd-branch
             # but not: dmd-2016-10-19 or dmd-branch-2016-10-20
             #          dmd-2.068.0 or dmd-2.068.2-5
+            #          dmd-2.064 or dmd-2.064-0
             if [[ ! $input_compiler =~ -[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] &&
-               [[ ! $input_compiler =~ -[0-9][.][0-9]{3}[.][0-9]{1,3}(-[0-9]{1,3})? ]]; then
+               [[ ! $input_compiler =~ -[0-9][.][0-9]{3}[.][0-9]{1,3}(-[0-9]{1,3})? ]] &&
+               [[ ! $input_compiler =~ -[0-9][.][0-9]{3}(.[0-9]{1,3})? ]]; then
                 local url=http://downloads.dlang.org/nightlies/$input_compiler/LATEST
                 logV "Determing latest $input_compiler version ($url)."
                 COMPILER="dmd-$(fetch "$url")"
@@ -787,10 +789,10 @@ download_and_unpack() {
         if [[ "${#files[@]}" -eq 1 && -d "${files[0]}" ]]; then
             # Single directory at the top of the archive,
             # as is common with .tar archives. Move it out.
-            find "$tmp"/target -mindepth 2 -maxdepth 2 -exec mv -t "$tmp" {} \+
+            find "$tmp"/target -mindepth 2 -maxdepth 2 -exec sh -c "exec mv "\$@" '$tmp'" sh {} \+
             rmdir "$tmp"/target/*
         else
-            find "$tmp"/target -mindepth 1 -maxdepth 1 -exec mv -t "$tmp" {} \+
+            find "$tmp"/target -mindepth 1 -maxdepth 1 -exec sh -c "exec mv "\$@" '$tmp'" sh {} \+
         fi
         rmdir "$tmp"/target
     fi

--- a/test/t/base.sh
+++ b/test/t/base.sh
@@ -3,6 +3,7 @@
 set -uexo pipefail
 
 compilers=(
+    dmd-2.064
     dmd-2.069.2
     dmd-2.071.2
     dmd-2.077.1
@@ -11,6 +12,7 @@ compilers=(
 )
 
 versions=(
+    'DMD64 D Compiler v2.064'
     'DMD64 D Compiler v2.069.2'
     'DMD64 D Compiler v2.071.2'
     'DMD64 D Compiler v2.077.1'
@@ -19,6 +21,7 @@ versions=(
 )
 
 frontendVersions=(
+    '2064'
     '2069'
     '2071'
     '2077'
@@ -58,8 +61,16 @@ do
     ./script/install.sh $compiler
 
     . ~/dlang/$compiler/activate
-    compilerVersion=$($DC --version | sed -n 1p | tr -d '\r')
+    # test compiler version
+    if [[ "$compiler" == "dmd-2.064" ]] ; then
+        # older dmd versions can't be run on CI
+        deactivate
+        ./script/install.sh uninstall $compiler
+        continue
+    fi
+
     expectedVersion="${versions[$idx]}"
+    compilerVersion=$($DC --version | sed -n 1p | tr -d '\r')
     # We don't ship 64-bit binaries on Windows
     if [[ "$OS" == *_NT-* ]]; then expectedVersion=${expectedVersion/DMD64/DMD32}; fi
     test "$compilerVersion" = "$expectedVersion"


### PR DESCRIPTION
I uploaded signatures files until 2.060. I doubt anyone is using older DMD installations on their CI.
After all, it even fails to run here on TravisCI.