### PR TITLE
[build_all.d] Upgrade MinGW-based lib binaries to v8.0.0

### DIFF
--- a/create_dmd_release/build_all.d
+++ b/create_dmd_release/build_all.d
@@ -516,8 +516,8 @@ int main(string[] args)
     enum libC = "snn.lib";
     enum libCurl = "libcurl-7.68.0-WinSSL-zlib-x86-x64.zip";
     enum omflibs = "omflibs-winsdk-10.0.16299.15.zip";
-    enum mingwtag = "mingw-libs-7.0.0-3";
-    enum mingwlibs = mingwtag ~ ".zip";               enum mingw_sha = hexString!"640c080e7fb120dd66cdfe18f9c56fe39dd901c24c32347dae57f80dce931b61";
+    enum mingwtag = "mingw-libs-8.0.0";
+    enum mingwlibs = mingwtag ~ ".zip";               enum mingw_sha = hexString!"8c1619234ca8370b742a08a30b13bf9bdb333f842ed0ea02cafe9054c68adc97";
     enum lld = "lld-link-9.0.0-seh.zip";              enum lld_sha   = hexString!"ffde2eb0e0410e6985bbbb44c200b21a2b2dd34d3f8c3411f5ca5beb7f67ba5b";
     enum lld64 = "lld-link-9.0.0-seh-x64.zip";        enum lld64_sha = hexString!"c24f9b8daf7ec49c7bfb96d7c0de4e3ced76f9777114f7601bdd4185a2cc7338";
 


### PR DESCRIPTION
I uploaded the binaries to downloads.dlang.org as well (though we don't need to do this anymore as we fetch it directly from the GitHub release).

See https://github.com/dlang/installer/pull/474 for details.