### PR TITLE
Fix Issue 21433 - "bash: line 952: --list-keys: command not found" wh…

### DIFF
--- a/script/install.sh
+++ b/script/install.sh
@@ -946,7 +946,7 @@ verify() {
     path="$1"
     urls=("${@:2}")
     : "${GPG:=$(find_gpg)}"
-    if [ "$GPG" = x ]; then
+    if [ -z "$GPG" ]; then
         return
     fi
     if ! $GPG --list-keys >/dev/null; then


### PR DESCRIPTION
…en running install.sh on Catalina