### PR TITLE
fix Issue 21488 - Bundled 32-bit dlang tools (ddemangle, dustmite, rdmd) segfault on startup

### DIFF
--- a/linux/dmd_deb.sh
+++ b/linux/dmd_deb.sh
@@ -328,7 +328,7 @@ else
 	;
 
 	[Environment32]
-	DFLAGS=-I/usr/include/dmd/phobos -I/usr/include/dmd/druntime/import -L-L/usr/lib/i386-linux-gnu -L--export-dynamic
+	DFLAGS=-I/usr/include/dmd/phobos -I/usr/include/dmd/druntime/import -L-L/usr/lib/i386-linux-gnu -L--export-dynamic -fPIC
 
 	[Environment64]
 	DFLAGS=-I/usr/include/dmd/phobos -I/usr/include/dmd/druntime/import -L-L/usr/lib/x86_64-linux-gnu -L--export-dynamic -fPIC

--- a/linux/dmd_rpm.sh
+++ b/linux/dmd_rpm.sh
@@ -246,7 +246,7 @@ do
 		;
 		
 		[Environment32]
-		DFLAGS=-I/usr/include/dmd/phobos -I/usr/include/dmd/druntime/import -L-L/usr/lib -L--export-dynamic
+		DFLAGS=-I/usr/include/dmd/phobos -I/usr/include/dmd/druntime/import -L-L/usr/lib -L--export-dynamic -fPIC
 		' | sed 's/^\t\t//' > etc/dmd.conf
 		if [ "$ARCH" = "x86_64" ]
 		then


### PR DESCRIPTION
All other parts of dmd have been covered.  It's just the installer dmd.conf that is preventing all _compiled_ 32-bit programs from segfaulting.