### PR TITLE
Disable LTO for FreeBSD

### DIFF
--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -372,7 +372,10 @@ void buildAll(Bits bits, string branch, bool dmdOnly=false)
     auto hostDMDEnv = " HOST_DC="~hostDMD~" HOST_DMD="~hostDMD;
     auto isRelease = " ENABLE_RELEASE=1";
     //Enable lto for everything.
-    auto ltoOption = " ENABLE_LTO=1";
+    version (FreeBSD)
+        auto ltoOption = " ENABLE_LTO=0";
+    else
+        auto ltoOption = " ENABLE_LTO=1";
     auto latest = " LATEST="~branch;
     // PIC libraries on amd64 for PIE-by-default distributions, see Bugzilla 16794
     version (linux)


### PR DESCRIPTION
The generated dmd segfaults immediatly

CC @maxhaton 