### PR TITLE
Add a template to build releases on Github Actions

### DIFF
--- a/.github/workflows/build_release_template.yml
+++ b/.github/workflows/build_release_template.yml
@@ -1,0 +1,309 @@
+# Reusable workflow for Github Action which builds release for specified revisions
+#
+# This script builds and packages a release for Linux, Windows, OSX and FreeBSD
+# using the specified revision. The generated archives are returned as build
+# artifacts
+#
+# Job overview:
+# 1. Generates the documentation included in each release
+# 2. Builds the actual release (using a matrix over all targets)
+
+name: build-release
+
+on:
+  # Only runs when called from another workflow
+  workflow_call:
+    inputs:
+      # Determines the branch for all repositories
+      release_branch:
+        type: string
+        required: true
+        description: Revision to build as a new release
+
+    # Expose the commit hash of the built revisions for dmd / druntime / phobos
+    # (useful for error reporting / logs / ...)
+    outputs:
+      dmd-revision:
+        value: ${{ jobs.build-docs.outputs.dmd-revision }}
+
+      druntime-revision:
+        value: ${{ jobs.build-docs.outputs.druntime-revision }}
+
+      phobos-revision:
+        value: ${{ jobs.build-docs.outputs.phobos-revision }}
+
+jobs:
+  # Build the documentation used by all releases
+  build-docs:
+    name: Build documentation for all repos
+
+    outputs:
+      dmd-revision: ${{ steps.get-revisions.outputs.dmd-revision }}
+      druntime-revision: ${{ steps.get-revisions.outputs.druntime-revision }}
+      phobos-revision: ${{ steps.get-revisions.outputs.phobos-revision }}
+
+    steps:
+      # Clone all required repos
+      - name: Clone dmd
+        uses: actions/checkout@v2
+        with:
+          repository: 'dlang/dmd'
+          ref: ${{ inputs.release_branch }}
+          path: 'dmd'
+
+      - name: Clone druntime
+        uses: actions/checkout@v2
+        with:
+          repository: 'dlang/druntime'
+          ref: ${{ inputs.release_branch }}
+          path: 'druntime'
+
+      - name: Clone phobos
+        uses: actions/checkout@v2
+        with:
+          repository: 'dlang/phobos'
+          ref: ${{ inputs.release_branch }}
+          path: 'phobos'
+
+      - name: Clone dlang.org
+        uses: actions/checkout@v2
+        with:
+          repository: 'dlang/dlang.org'
+          ref: ${{ inputs.release_branch }}
+          path: 'dlang.org'
+
+      # Fetch host compiler
+      - uses: dlang-community/setup-dlang@v1
+        name: Install host DMD to build the documentation
+        with:
+          compiler: dmd-latest
+
+      # Actually build the docs
+      - name: Build docs and man pages
+        shell: bash
+        run: |
+          set -euox pipefail
+          N=$(( 2 * $(nproc) ))
+
+          # Build minimal host compiler (sometimes not triggered by dlang.org/posix.mak)
+          make -f posix.mak -j$N -C druntime
+
+          # Build docs and include the man pages
+          make -f posix.mak -j$N -C dlang.org release
+          cp -r dmd/generated/docs/man dlang.org/web/
+
+      # Save the generated documentation for the target-specific builds
+      - name: Upload generated docs as a temporary artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: dmd-documentation
+          path: dlang.org/web
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Determine revisions
+        id: get-revisions
+        shell: bash
+        run: |
+          set -euox pipefail
+
+          for REPO in dmd druntime phobos
+          do
+            REV=$( git -C $REPO rev-parse HEAD )
+            echo "::set-output name=$REPO-revision::$REV"
+          done
+
+    runs-on: ubuntu-latest
+
+  # Build and package a new release for each platform
+  build-all-releases:
+    name: Build release for ${{ matrix.target }}  on ${{ matrix.os }}
+    needs: build-docs
+    timeout-minutes: 60
+
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: linux
+          - os: macos-latest
+            target: osx
+          - os: windows-latest
+            target: windows
+          # FreeBSD is built on an additional VM
+          - os: macos-10.15
+            target: freebsd
+
+    steps:
+
+      #################################################################
+      # Install the system dependencies required to build and run
+      # the actual release scripts
+      #
+      # Linux implementation based on `linux_both` in build_all.d and
+      # some additional experimentation to get curl working
+      #
+      - name: Install dependencies for linux
+        if: matrix.target == 'linux'
+        shell: bash
+        run: |
+          set -euox pipefail
+
+          # Install base dependencies (including multlib support)
+          sudo dpkg --add-architecture i386
+          sudo apt -y update
+          sudo apt -y install --no-install-recommends \
+              build-essential \
+              ca-certificates \
+              curl \
+              dpkg-dev \
+              fakeroot \
+              g++ \
+              g++-multilib \
+              gcc \
+              git \
+              gpg \
+              gpg-agent \
+              libcurl4 \
+              libcurl4-openssl-dev \
+              libcurl4:i386 \
+              libxml2 \
+              make \
+              p7zip-full \
+              rpm \
+              rsync \
+              unzip \
+              xz-utils
+
+          # Save some space
+          sudo apt clean
+
+      #################################################################
+      # Install latest LDC used to compile the release scripts and to
+      # determine the currently available version number
+      #
+      - uses: dlang-community/setup-dlang@v1
+        name: Install latest LDC
+        if: matrix.target != 'freebsd'
+        with:
+          compiler: ldc-latest
+
+      #################################################################
+      # Clone dlang/installer which provides the actual build scripts
+      #
+      - name: Clone installer repo
+        uses: actions/checkout@v2
+
+      #################################################################
+      # Load the generated documentation in the create_dmd_release folder
+      #
+      - name: Download docs generated by the previous job
+        uses: actions/download-artifact@v2
+        with:
+          name: dmd-documentation
+          path: create_dmd_release/docs
+
+      #################################################################
+      # Build for the current target using build_all.d from installer
+      #
+      - name: Fetch common resources and run build_all.d for ${{ matrix.target }}
+        id: build
+        if: matrix.target != 'freebsd'
+        shell: bash
+        run: |
+          set -euox pipefail
+
+          # Fetch GPG key used to sign the generated binaries
+          curl https://dlang.org/d-keyring.gpg -o d-keyring.gpg
+          gpg --import d-keyring.gpg
+
+          # Compile release builder
+          cd create_dmd_release
+          ldmd2 -g -m64 --link-defaultlib-debug -version=NoVagrant -i build_all.d
+
+          # Determine installed LDC version
+          LDC=$(head -n 1 < <(ldc2 --version) | cut -d'(' -f2 | cut -d')' -f1)
+
+          # WINDOWS: Fetch additional DM tools
+          if [[ "${{ matrix.target }}" == "windows" ]]
+          then
+
+            # Fetch DM make
+            curl http://downloads.dlang.org/other/dm857c.zip -o dmc.zip
+            7z x dmc.zip
+
+            # Fetch implib
+            curl http://ftp.digitalmars.com/bup.zip -o bup.zip
+            7z x bup.zip dm/bin/implib.exe
+
+            # Add DM binaries to the path
+            export PATH="$PWD/dm/bin;$PATH"
+
+            # Export VS dir
+            export LDC_VSDIR='C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise'
+          fi
+
+          # Workaround: Provide ldmd2 as dmd replacement as some tools assume DMD is present:
+          mkdir .pathext
+          ln -s "$(which ldmd2)" .pathext/dmd
+          if [[ "${{ matrix.target }}" == "windows" ]]
+          then
+            PATH="$PATH;$PWD/.pathext"
+          else
+            PATH="$PATH:$PWD/.pathext"
+          fi
+
+          # Build the release
+          ./build_all --targets=${{ matrix.target }} "v$LDC" ${{ inputs.release_branch }}
+
+      #################################################################
+      # FREEBSD: Build for the current target using build_all.d from installer
+      #
+      - name: Run build_all.d for FreeBSD in a dedicated VM
+        if: matrix.target == 'freebsd'
+        uses: vmactions/freebsd-vm@v0.1.3
+        with:
+          usesh: true
+          # Need more RAM than the default 1G
+          mem: 4096
+          prepare: pkg install -y bash curl curlpp git gmake pkgconf gnupg rsync llvm90
+          run: |
+            set -eux
+
+            # Import key used to sign binaries
+            curl https://dlang.org/d-keyring.gpg -o d-keyring.gpg
+            gpg d-keyring.gpg
+
+            # Install ldc
+            curl https://dlang.org/install.sh -o install.sh
+            bash install.sh ldc -p .
+
+            # Use absolute paths because activate doesn't work correctly
+            LDC_BIN=$PWD/ldc-*/bin
+
+            # Determine installed LDC version
+            LDC=$($LDC_BIN/ldc2 --version | head -n 1 | cut -d'(' -f2 | cut -d')' -f1)
+
+            # Determine additional linker flags to make -lcurl work
+            EXTRA_FLAGS="-L$(pkg-config --libs-only-L libcurl)"
+
+            # Actually build the release
+            cd create_dmd_release
+            $LDC_BIN/ldmd2 -g -m64 --link-defaultlib-debug -version=NoVagrant -i build_all.d $EXTRA_FLAGS
+            ./build_all --targets=${{ matrix.target }} "v$LDC" ${{ inputs.release_branch }}
+
+      #################################################################
+      # Save the target-specific release as a artifact s.t. the next
+      # job(s) have access to all generated releases
+      #
+      - name: Upload generated release as a temporary artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: dmd-release
+          path: |
+            ${{ github.workspace }}/create_dmd_release/build/*
+            !${{ github.workspace }}/create_dmd_release/build/*.zip
+          retention-days: 1
+          if-no-files-found: error
+
+    runs-on: ${{ matrix.os }}

--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -1,0 +1,155 @@
+# Github Action to verify the releases build by the current repo / the workflow
+# defined in build_release_template.yml.
+
+name: test_release
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build_release:
+    name: "Default release build"
+    if: ${{ github.repository == 'dlang/installer' }}
+    uses: ./.github/workflows/build_release_template.yml
+    with:
+      # Test master for now, could also be safe with stable
+      release_branch: master
+
+  validate_build:
+    name: Validate results of build_release_template.yml
+    needs: build_release
+
+    strategy:
+      fail-fast: false
+      matrix:
+
+        target:
+          - {
+            host: windows-latest,
+            os: windows,
+            build: dmd.master.windows.7z
+          }
+          - {
+            host: macos-latest,
+            os: osx,
+            build: dmd.master.osx.tar.xz
+          }
+          - {
+            host: ubuntu-latest,
+            os: linux,
+            build: dmd.master.linux.tar.xz
+          }
+          - {
+            host: macos-10.15,
+            os: freebsd,
+            build: dmd.master.freebsd-64.tar.xz
+          }
+
+    runs-on: ${{ matrix.target.host }}
+
+    steps:
+      - name: Download generated releases from the artifacts
+        id: download-release
+        uses: actions/download-artifact@v2
+        with:
+          name: dmd-release
+
+      # Check whether the generated compiler is included in the artifacts and
+      # contains everything needed to compile & execute D programms.
+      - name: Check ${{ matrix.target.os }} artifacts
+        id: check
+        if: ${{ matrix.target.os != 'freebsd' }}
+        shell: bash
+        run: |
+          set -eux
+
+          # Extract the release and determine the targets to test (primarily -m64 except for Windows)
+          if [ "${{ matrix.target.os }}" == "windows" ]
+          then
+            7z x -y ${{ matrix.target.build }}
+            TARGETS="-m32 -m32mscoff -m64"
+
+            # FIXME: -m32/-m32mscoff currently broken, tries to run Optlink using MSCOFF files
+            TARGETS="-m32omf -m64"
+          else
+            tar xf ${{ matrix.target.build }}
+            TARGETS="-m64"
+          fi
+
+          cat - > hello.d <<-EOF
+            import std.stdio;
+
+            void main()
+            {
+              writeln("Hello, World!");
+            }
+          EOF
+
+          for DMD in dmd2/${{ matrix.target.os }}/bin*/dmd
+          do
+            $DMD --version
+
+            # FIXME: Windows sc.ini currently broken, remove once fixed upstream
+            if [ "${{ matrix.target.os }}" == "windows" ]; then
+              # Extend path s.t. Optlink can always be found
+              export PATH="$PATH:$(dirname $DMD)"
+            fi
+
+            for TARGET in $TARGETS
+            do
+              $DMD $TARGET -of=hello hello.d
+              ./hello
+            done
+          done
+
+      - name: Check ${{ matrix.target.os }} artifacts in a VM
+        if: ${{ matrix.target.os == 'freebsd' }}
+        uses: cross-platform-actions/action@v0.3.1
+        with:
+          operating_system: freebsd
+          version: 12.2
+          shell: bash
+          run: |
+            set -eux
+
+            tar xf ${{ matrix.target.build }}
+
+            DMD="dmd2/${{ matrix.target.os }}/bin64/dmd"
+            $DMD --version
+            $DMD -of=hello - <<-EOF
+              import std.stdio;
+
+              void main()
+              {
+                writeln("Hello, World!");
+              }
+            EOF
+            ./hello
+
+            # Don't need to sink back these files
+            rm -rf dmd* hello*
+
+  validate_build_metadata:
+    name: Validate outputs of build_release_template.yml
+    runs-on: ubuntu-latest
+    needs: build_release
+
+    # Revisions built above
+    env:
+      DMD_REF: ${{ needs.build_release.outputs.dmd-revision }}
+      DRUNTIME_REF: ${{ needs.build_release.outputs.druntime-revision }}
+      PHOBOS_REF: ${{ needs.build_release.outputs.phobos-revision }}
+
+    steps:
+      - name: Check outputs
+        shell: bash
+        run: |
+          set -eux
+
+          # Check that revisions are set
+          [ "$DMD_REF" != "" ]
+          [ "$DRUNTIME_REF" != "" ]
+          [ "$PHOBOS_REF" != "" ]

--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -371,8 +371,11 @@ void buildAll(Bits bits, string branch, bool dmdOnly=false)
     }
     auto hostDMDEnv = " HOST_DC="~hostDMD~" HOST_DMD="~hostDMD;
     auto isRelease = " ENABLE_RELEASE=1";
-    //Enable lto for everything.
-    auto ltoOption = " ENABLE_LTO=1";
+    //Enable lto for everything except FreeBSD - the generated dmd segfaults immediatly.
+    version (FreeBSD)
+        auto ltoOption = " ENABLE_LTO=0";
+    else
+        auto ltoOption = " ENABLE_LTO=1";
     auto latest = " LATEST="~branch;
     // PIC libraries on amd64 for PIE-by-default distributions, see Bugzilla 16794
     version (linux)

--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -476,6 +476,10 @@ void buildAll(Bits bits, string branch, bool dmdOnly=false)
         // Build the tools using the host compiler
         makecmd = makecmd.replace(dmdEnv, " DMD=" ~ hostDMD);
 
+        // Override DFLAGS because we're using the host compiler rather than
+        // the freshly built one (posix.mak defaults to the generated dmd)
+        makecmd ~= ` DFLAGS="-O -release -m` ~ bitsStr ~ '"';
+
         info("Building Tools "~bitsDisplay);
         changeDir(cloneDir~"/tools");
         run(makecmd~" rdmd");


### PR DESCRIPTION
This action is based off the dmd nightlies but also includes some required changes to make it available as a reuseable workflow. This allows actual workflows to call this template, e.g. for pull requests against this repository.

Also includes a test action that uses the new action & verifies the packaged compiler by building and running some basic program.

Note: The windows checks are partially disabled due to an upstream issue
 (invalid `sc.ini` due to the Win32 OMF => MSCOFF change).

Includes the following changes to restore the currently broken release build:
- Disables LTO for FreeBSD because the generated DMD segfaults immediatly
- Provides custom DFLAGS when building the tools because the defaults found in `posix.mak` assume a freshly built dmd regardless of the actual `DMD`.

Example: https://github.com/MoonlightSentinel/installer/actions/runs/1802351875

CC @maxhaton @thewilsonator 