### PR TITLE
Retain original sc.ini instead of generating a new one

### DIFF
--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -469,6 +469,10 @@ void buildAll(Bits bits, string branch, bool dmdOnly=false)
 
     if(build64BitTools || bits == Bits.bits32)
     {
+
+        // Build the tools using the host compiler
+        makecmd = makecmd.replace(dmdEnv, " DMD=" ~ hostDMD);
+
         info("Building Tools "~bitsDisplay);
         changeDir(cloneDir~"/tools");
         run(makecmd~" rdmd");


### PR DESCRIPTION
Only append the required `LIB` path s.t. the remaining values match the expected defaults from dmd. Required because the generated config contains an invalid `LINKCMD` with the new default for 32 bit windows.

Also changes the `tools` build to use host compiler to avoid issues w.r.t. the OMF => MsCoff default transition (as LDC defaults to MsCoff for 32).

---

Extracted from #494 
