### PR TITLE
Enforce DMD as the default compiler for rdmd

### DIFF
--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -478,7 +478,7 @@ void buildAll(Bits bits, string branch, bool dmdOnly=false)
 
         // Override DFLAGS because we're using the host compiler rather than
         // the freshly built one (posix.mak defaults to the generated dmd)
-        makecmd ~= ` DFLAGS="-O -release -m` ~ bitsStr ~ '"';
+        makecmd ~= ` DFLAGS="-O -release -m` ~ bitsStr ~ ` -version=DefaultCompiler_DMD"`;
 
         info("Building Tools "~bitsDisplay);
         changeDir(cloneDir~"/tools");

--- a/test/release/validate_release.sh
+++ b/test/release/validate_release.sh
@@ -46,7 +46,7 @@ done
 
 for RDMD in $GEN/dmd2/$OS/bin*/rdmd$EXE
 do
-	$RDMD --compiler=$DMD -m64 $DIR/hello.d
+	$RDMD -m64 $DIR/hello.d
 done
 
 for DDEMANGLE in $GEN/dmd2/$OS/bin*/ddemangle$EXE


### PR DESCRIPTION
Defining `-version=DefaultCompiler_DMD` ensures that rdmd defaults to DMD instead of the current host compiler (LDC).

See dlang/tools#442

CC @CyberShadow @rikkimax