### PR TITLE
Explicitly specify repo + branch when cloning installer

### DIFF
--- a/.github/workflows/build_release_template.yml
+++ b/.github/workflows/build_release_template.yml
@@ -20,6 +20,16 @@ on:
         required: true
         description: Revision to build as a new release
 
+      installer_repo:
+        type: string
+        default: 'dlang/installer'
+        description: dlang/installer or any fork hosting installer_branch
+
+      installer_branch:
+        type: string
+        default: 'master'
+        description: Branch providing the build scripts
+
     # Expose the commit hash of the built revisions for dmd / druntime / phobos
     # (useful for error reporting / logs / ...)
     outputs:
@@ -193,6 +203,9 @@ jobs:
       #
       - name: Clone installer repo
         uses: actions/checkout@v2
+        with:
+          repository: ${{ inputs.installer_repo }}
+          ref: ${{ inputs.installer_branch }}
 
       #################################################################
       # Load the generated documentation in the create_dmd_release folder

--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -18,6 +18,10 @@ jobs:
       # Test master for now, could also be safe with stable
       release_branch: master
 
+      # Empty = use the repository/branch that triggered the build
+      installer_repo:
+      installer_branch:
+
   validate_build:
     name: Validate results of build_release_template.yml
     needs: build_release


### PR DESCRIPTION
`actions/checkout` defaults to the repository + branch that triggered the build, not where the action is defined. They are not set explicitly based on workflow parameters s.t. the defaults can be override for e.g. pull requests.

---

Noticed the problem when trying to redirect the nightly build to `build_release_template` - the build failed because it cloned `dmd` instead of `installer`.