### PR TITLE
build_release_template: Use windows-2019 instead of windows-latest

### DIFF
--- a/.github/workflows/build_release_template.yml
+++ b/.github/workflows/build_release_template.yml
@@ -128,7 +128,7 @@ jobs:
             target: linux
           - os: macos-latest
             target: osx
-          - os: windows-latest
+          - os: windows-2019
             target: windows
           # FreeBSD is built on an additional VM
           - os: macos-10.15


### PR DESCRIPTION
The build script currently requires an existing VS 2019 installation. But `windows-latest` allows for runners with `windows-2022` which have VS 2022 installed.

---

Not sure why runs from my fork consistently used `windows-2019` runners.