### PR TITLE
Build tools in a single make instance

### DIFF
--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -482,9 +482,7 @@ void buildAll(Bits bits, string branch, bool dmdOnly=false)
 
         info("Building Tools "~bitsDisplay);
         changeDir(cloneDir~"/tools");
-        run(makecmd~" rdmd");
-        run(makecmd~" ddemangle");
-        run(makecmd~" dustmite");
+        run(makecmd~" rdmd ddemangle dustmite");
 
         removeFiles(cloneDir~"/tools", "*.{"~obj~"}", SpanMode.depth);
     }


### PR DESCRIPTION
Removes the overhead for multiple make instances and enables parallel builds.