### PR TITLE
Disable fail-fast on build-all-releases & fix nightlies

### DIFF
--- a/.azure-pipelines/build-winrelease.yml
+++ b/.azure-pipelines/build-winrelease.yml
@@ -14,6 +14,8 @@ steps:
       move ldc2-$(HOST_LDC_VERSION)-windows-multilib ldc2
       powershell -command "& { iwr http://downloads.dlang.org/other/dm857c.zip -OutFile dmc.zip }"
       7z x dmc.zip
+      powershell -command "& { iwr http://ftp.digitalmars.com/sppn.zip -OutFile sppn.zip }"
+      7z x -odm/bin sppn.zip
       powershell -command "& { iwr http://ftp.digitalmars.com/bup.zip -OutFile bup.zip }"
       7z x bup.zip dm/bin/implib.exe
       powershell -command "& { iwr https://nsis.sourceforge.io/mediawiki/images/c/c9/Inetc.zip -OutFile inetc.zip }"

--- a/.github/workflows/build_release_template.yml
+++ b/.github/workflows/build_release_template.yml
@@ -242,9 +242,11 @@ jobs:
           if [[ "${{ matrix.target }}" == "windows" ]]
           then
 
-            # Fetch DM make
+            # Fetch DMC (incl. DM make and sppn.exe)
             curl http://downloads.dlang.org/other/dm857c.zip -o dmc.zip
             7z x dmc.zip
+            curl http://ftp.digitalmars.com/sppn.zip -o sppn.zip
+            7z x -odm/bin sppn.zip
 
             # Fetch implib
             curl http://ftp.digitalmars.com/bup.zip -o bup.zip

--- a/.github/workflows/build_release_template.yml
+++ b/.github/workflows/build_release_template.yml
@@ -132,6 +132,7 @@ jobs:
     timeout-minutes: 60
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -328,12 +328,8 @@ void buildAll(Bits bits, string branch)
     auto msvcVarsX64 = "";
     auto msvcVarsX86 = "";
     auto msvcVars = "";
-    auto msvcEnv = "";
     version(Windows) if (bits == Bits.bits64)
     {
-        // Just overwrite any logic in makefiles and leave setup to vcvarsall.bat
-        msvcEnv = ` "VCDIR=" "SDKDIR=" "CC=cl" "CC32=cl" "LD=link" "AR=lib"`;
-
         // Setup MSVC environment for x64/x86 native builds
         auto vcVars = quote(buildPath(environment["LDC_VSDIR"], `VC\Auxiliary\Build\vcvarsall.bat`));
         msvcVarsX64 = vcVars~" x64 && ";
@@ -418,26 +414,26 @@ void buildAll(Bits bits, string branch)
 
     info("Building Druntime "~bitsDisplay);
     changeDir(cloneDir~"/druntime");
-    run(msvcVars~makecmd~pic~msvcEnv~makeTargetDruntime);
+    run(msvcVars~makecmd~pic~makeTargetDruntime);
     removeFiles(cloneDir~"/druntime", "*{"~obj~"}", SpanMode.depth,
         file => !file.baseName.startsWith("minit"));
 
     info("Building Phobos "~bitsDisplay);
     changeDir(cloneDir~"/phobos");
-    run(msvcVars~makecmd~pic~msvcEnv);
+    run(msvcVars~makecmd~pic);
     removeFiles(cloneDir~"/phobos", "*{"~obj~"}", SpanMode.depth);
 
     version (Windows) if (bits == Bits.bits64)
     {
         info("Building Druntime 32mscoff");
         changeDir(cloneDir~"/druntime");
-        run(msvcVarsX86~makecmd~msvcEnv~" druntime32mscoff");
+        run(msvcVarsX86~makecmd.replace(makeModel, " MODEL=32mscoff"));
         removeFiles(cloneDir~"/druntime", "*{"~obj~"}", SpanMode.depth,
                     file => !file.baseName.startsWith("minit"));
 
         info("Building Phobos 32mscoff");
         changeDir(cloneDir~"/phobos");
-        run(msvcVarsX86~makecmd~msvcEnv~" phobos32mscoff");
+        run(msvcVarsX86~makecmd.replace(makeModel, " MODEL=32mscoff"));
         removeFiles(cloneDir~"/phobos", "*{"~obj~"}", SpanMode.depth);
     }
 


### PR DESCRIPTION
So that we get all error messages, and for nightlies,
we can still publish the other releases if we want to.