### PR TITLE
Windows: Provision sppn.exe, required for druntime's errno.c

### DIFF
--- a/.github/workflows/build_release_template.yml
+++ b/.github/workflows/build_release_template.yml
@@ -241,9 +241,11 @@ jobs:
           if [[ "${{ matrix.target }}" == "windows" ]]
           then
 
-            # Fetch DM make
+            # Fetch DMC (incl. DM make and sppn.exe)
             curl http://downloads.dlang.org/other/dm857c.zip -o dmc.zip
             7z x dmc.zip
+            curl http://ftp.digitalmars.com/sppn.zip -o sppn.zip
+            7z x -odm/bin sppn.zip
 
             # Fetch implib
             curl http://ftp.digitalmars.com/bup.zip -o bup.zip


### PR DESCRIPTION
Analogous to https://github.com/dlang/dmd/blob/04d189077c0c672ad35be159cc879033807af8f8/.azure-pipelines/lib.sh#L55-L56.