### PR TITLE
fix failing codesign cert fingerprint

### DIFF
--- a/create_dmd_release/build_all.d
+++ b/create_dmd_release/build_all.d
@@ -421,7 +421,8 @@ void getCodesignCerts(string tgtDir)
     {
         writeln("Getting fingerprint for codesign cert " ~ de.name);
         auto content = runCapture(
-            "openssl pkcs12 -in "~escapeShellFileName(de.name)~" -nodes"~
+            "openssl pkcs12 -provider default -provider legacy"~
+              " -in "~escapeShellFileName(de.name)~" -nodes"~
               " -password file:"~escapeShellFileName(de.name.setExtension(".pass"))~
             "| openssl x509 -noout -fingerprint"
         );


### PR DESCRIPTION
- RC2-40-CBC algo now in legacy provider
  (see openssl/openssl#12227)
