### PR TITLE
fix OSX build issues

### DIFF
--- a/create_dmd_release/build_all.d
+++ b/create_dmd_release/build_all.d
@@ -152,8 +152,11 @@ struct Box
         }
         else
         {
-            // run scp with retry as fetching sth. fails (Windows OpenSSH-server)
-            auto cmd = "scp -r -F "~sshcfg~" "~src~" "~tgt~" > /dev/null";
+            immutable cmd = os == OS.osx ?
+                // scp with OSX requires target folders to exist before recursive copy
+                "rsync -a -e 'ssh -F "~sshcfg~"' "~src~" "~tgt~" > /dev/null" :
+                "scp -r -F "~sshcfg~" "~src~" "~tgt~" > /dev/null";
+            // run scp with retry as fetching st. fails (Windows OpenSSH-server)
             if (runStatus(cmd) && runStatus(cmd))
                 run(cmd);
         }

--- a/create_dmd_release/build_all.d
+++ b/create_dmd_release/build_all.d
@@ -114,6 +114,8 @@ struct Box
 
             // save the ssh config file
             run("cd "~_tmpdir~"; vagrant ssh-config > ssh.cfg;");
+            if (platform.os == OS.osx)
+                run("cd "~_tmpdir~"; echo -e '  HostKeyAlgorithms +ssh-rsa\n  PubkeyAcceptedKeyTypes +ssh-rsa' >> ssh.cfg;");
         }
     }
 

--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -365,6 +365,8 @@ void buildAll(Bits bits, string branch)
         auto ltoOption = " ENABLE_LTO=0";
     else version (linux)
         auto ltoOption = " ENABLE_LTO=" ~ (bits == Bits.bits32 ? "0" : "1");
+    else version (OSX)
+        auto ltoOption = " ENABLE_LTO=0";
     else
         auto ltoOption = " ENABLE_LTO=1";
     auto latest = " LATEST="~branch;


### PR DESCRIPTION
- temporarily disable LTO on OSX to workaround dated linker :disappointed:
- scp with OSX requires target folders to exist before recursive copy
- workaround dated OSX sshd host key algos

We have to get 2.100.2 out and don't want to defer the build any longer. LTO for OSX was sometimes disabled beforehand.
LTO support in the dated linker/OSX image has been a gamble for quite a while.
This will be fixed by moving the build process to a CI system with up-to-date OSX/XCode.