### PR TITLE
merge stable

### DIFF
--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -357,6 +357,8 @@ void buildAll(Bits bits, string branch)
         auto ltoOption = " ENABLE_LTO=0";
     else version (linux)
         auto ltoOption = " ENABLE_LTO=" ~ (bits == Bits.bits32 ? "0" : "1");
+    else version (OSX)
+        auto ltoOption = " ENABLE_LTO=0";
     else
         auto ltoOption = " ENABLE_LTO=1";
     auto latest = " LATEST="~branch;


### PR DESCRIPTION
- fix copying linux packages
- disable codesigning by default for now
- fixup ee0c33dddc - conditional codesign
- workaround dated OSX sshd host key algos
- scp with OSX requires target folders to exist before recursive copy
- temporarily disable LTO on OSX to workaround dated linker
