### PR TITLE
[github] Bump FreeBSD VM host image to macOS-12

### DIFF
--- a/.github/workflows/build_release_template.yml
+++ b/.github/workflows/build_release_template.yml
@@ -131,7 +131,7 @@ jobs:
           - os: windows-2019
             target: windows
           # FreeBSD is built on an additional VM
-          - os: macos-10.15
+          - os: macos-12
             target: freebsd
 
     steps:
@@ -266,7 +266,7 @@ jobs:
       #
       - name: Run build_all.d for FreeBSD in a dedicated VM
         if: matrix.target == 'freebsd'
-        uses: vmactions/freebsd-vm@v0.1.6
+        uses: vmactions/freebsd-vm@v0.2.9
         with:
           usesh: true
           # Need more RAM than the default 1G

--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -40,7 +40,7 @@ jobs:
           - host: ubuntu-latest
             os: linux
             build: dmd.${{ github.base_ref || github.ref_name }}.linux.tar.xz
-          - host: macos-10.15
+          - host: macos-12
             os: freebsd
             build: dmd.${{ github.base_ref || github.ref_name }}.freebsd-64.tar.xz
 
@@ -70,7 +70,7 @@ jobs:
 
       - name: Check ${{ matrix.os }} artifacts in a VM
         if: ${{ matrix.os == 'freebsd' }}
-        uses: cross-platform-actions/action@v0.3.1
+        uses: cross-platform-actions/action@v0.6.2
         with:
           operating_system: freebsd
           version: 12.2


### PR DESCRIPTION
Github is removing 10.15 soon.  Bumped the related actions to their latest versions, to ensure that they work with newer versions of macOS hosts.