### PR TITLE
Update downloads.dlang.org links to use https

### DIFF
--- a/.azure-pipelines/build-winrelease.yml
+++ b/.azure-pipelines/build-winrelease.yml
@@ -12,7 +12,7 @@ steps:
       powershell -command "& { iwr https://github.com/ldc-developers/ldc/releases/download/v$(HOST_LDC_VERSION)/ldc2-$(HOST_LDC_VERSION)-windows-multilib.7z -OutFile ldc.7z }"
       7z x ldc.7z
       move ldc2-$(HOST_LDC_VERSION)-windows-multilib ldc2
-      powershell -command "& { iwr http://downloads.dlang.org/other/dm857c.zip -OutFile dmc.zip }"
+      powershell -command "& { iwr https://downloads.dlang.org/other/dm857c.zip -OutFile dmc.zip }"
       7z x dmc.zip
       powershell -command "& { iwr http://ftp.digitalmars.com/sppn.zip -OutFile sppn.zip }"
       7z x -odm/bin sppn.zip

--- a/.github/workflows/build_release_template.yml
+++ b/.github/workflows/build_release_template.yml
@@ -232,7 +232,7 @@ jobs:
           then
 
             # Fetch DMC (incl. DM make and sppn.exe)
-            curl http://downloads.dlang.org/other/dm857c.zip -o dmc.zip
+            curl https://downloads.dlang.org/other/dm857c.zip -o dmc.zip
             7z x dmc.zip
             curl http://ftp.digitalmars.com/sppn.zip -o sppn.zip
             7z x -odm/bin sppn.zip

--- a/create_dmd_release/build_all.d
+++ b/create_dmd_release/build_all.d
@@ -607,10 +607,10 @@ int main(string[] args)
     {
         fetchFile("http://ftp.digitalmars.com/"~optlink, cacheDir~"/"~optlink);
         fetchFile("http://ftp.digitalmars.com/"~libC, cacheDir~"/"~libC);
-        fetchFile("http://downloads.dlang.org/other/"~libCurl, cacheDir~"/"~libCurl, verifySignature);
-        fetchFile("http://downloads.dlang.org/other/"~omflibs, cacheDir~"/"~omflibs, verifySignature);
-        fetchFile("http://downloads.dlang.org/other/"~lld, cacheDir~"/"~lld, verifySignature, lld_sha);
-        fetchFile("http://downloads.dlang.org/other/"~lld64, cacheDir~"/"~lld64, verifySignature, lld64_sha);
+        fetchFile("https://downloads.dlang.org/other/"~libCurl, cacheDir~"/"~libCurl, verifySignature);
+        fetchFile("https://downloads.dlang.org/other/"~omflibs, cacheDir~"/"~omflibs, verifySignature);
+        fetchFile("https://downloads.dlang.org/other/"~lld, cacheDir~"/"~lld, verifySignature, lld_sha);
+        fetchFile("https://downloads.dlang.org/other/"~lld64, cacheDir~"/"~lld64, verifySignature, lld64_sha);
         fetchFile("https://github.com/dlang/installer/releases/download/"~mingwtag~"/"~mingwlibs, cacheDir~"/"~mingwlibs, verifySignature, mingw_sha);
     }
 

--- a/script/install.sh
+++ b/script/install.sh
@@ -635,11 +635,11 @@ install_dlang_installer() {
     tmp=$(mkdtemp)
     local mirrors=(
         "https://dlang.org/install.sh"
-        "https://s3-us-west-2.amazonaws.com/downloads.dlang.org/other/install.sh"
+        "https://downloads.dlang.org/other/install.sh"
     )
     local keyring_mirrors=(
         "https://dlang.org/d-keyring.gpg"
-        "https://s3-us-west-2.amazonaws.com/downloads.dlang.org/other/d-keyring.gpg"
+        "https://downloads.dlang.org/other/d-keyring.gpg"
     )
 
     mkdir -p "$ROOT"

--- a/script/install.sh
+++ b/script/install.sh
@@ -666,7 +666,7 @@ resolve_latest() {
     case $input_compiler in
         dmd)
             local mirrors=(
-                "http://downloads.dlang.org/releases/LATEST"
+                "https://downloads.dlang.org/releases/LATEST"
                 "http://ftp.digitalmars.com/LATEST"
             )
             logV "Determing latest dmd version (${mirrors[0]})."
@@ -674,7 +674,7 @@ resolve_latest() {
             ;;
         dmd-beta)
             local mirrors=(
-                "http://downloads.dlang.org/pre-releases/LATEST"
+                "https://downloads.dlang.org/pre-releases/LATEST"
                 "http://ftp.digitalmars.com/LATEST_BETA"
             )
             logV "Determing latest dmd-beta version (${mirrors[0]})."
@@ -691,7 +691,7 @@ resolve_latest() {
             if [[ ! $input_compiler =~ -[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] &&
                [[ ! $input_compiler =~ -[0-9][.][0-9]{3}[.][0-9]{1,3}(-[0-9]{1,3})? ]] &&
                [[ ! $input_compiler =~ -[0-9][.][0-9]{3}(.[0-9]{1,3})? ]]; then
-                local url=http://downloads.dlang.org/nightlies/$input_compiler/LATEST
+                local url=https://downloads.dlang.org/nightlies/$input_compiler/LATEST
                 logV "Determing latest $input_compiler version ($url)."
                 COMPILER="dmd-$(fetch "$url")"
             # rewrite dmd-2016-10-19 -> dmd-master-2016-10-19 (default branch for nightlies)
@@ -778,12 +778,12 @@ install_compiler() {
         local mirrors
         if [ -n "${BASH_REMATCH[3]}" ]; then # pre-release
             mirrors=(
-                "http://downloads.dlang.org/pre-releases/2.x/$ver/$basename$ext"
+                "https://downloads.dlang.org/pre-releases/2.x/$ver/$basename$ext"
                 "http://ftp.digitalmars.com/$basename$ext"
             )
         else
             mirrors=(
-                "http://downloads.dlang.org/releases/2.x/$ver/$basename$ext"
+                "https://downloads.dlang.org/releases/2.x/$ver/$basename$ext"
                 "http://ftp.digitalmars.com/$basename$ext"
             )
         fi
@@ -802,7 +802,7 @@ install_compiler() {
         fi
         local ext
         test $OS = windows && ext=.7z || ext=.tar.xz
-        local url="http://downloads.dlang.org/nightlies/$1/$basename$ext"
+        local url="https://downloads.dlang.org/nightlies/$1/$basename$ext"
 
         download_and_unpack_with_verify "$ROOT/$compiler" "$url"
 

--- a/windows/build_mingw.bat
+++ b/windows/build_mingw.bat
@@ -11,7 +11,7 @@ set GITHUB_RELEASE=https://github.com/dlang/installer/releases/download/%TAG%/%A
 REM Stop early if the artifact already exists
 powershell -Command "Invoke-WebRequest %GITHUB_RELEASE% -OutFile %ARTIFACTPATH%" && exit /B 0
 
-set DMD_URL=http://downloads.dlang.org/releases/2.x/%D_VERSION%/dmd.%D_VERSION%.windows.7z
+set DMD_URL=https://downloads.dlang.org/releases/2.x/%D_VERSION%/dmd.%D_VERSION%.windows.7z
 echo DMD_URL=%DMD_URL%
 powershell -Command "Invoke-WebRequest %DMD_URL% -OutFile dmd2.7z" || exit /B 1
 7z x dmd2.7z || exit /B 1

--- a/windows/d2-installer.nsi
+++ b/windows/d2-installer.nsi
@@ -58,7 +58,7 @@
 !define VCRedistx64Filename "vcredist_x64.exe"
 
 ; URLs
-!define BaseURL "http://downloads.dlang.org"
+!define BaseURL "https://downloads.dlang.org"
 !define BaseURLAlt "http://ftp.digitalmars.com"
 !define VisualDBaseURL "https://github.com/dlang/visuald/releases/download"
 


### PR DESCRIPTION
This is now possible now the site now has a new front for its bucket.