### PR TITLE
Remove workarounds for old OSX release image

### DIFF
--- a/create_dmd_release/build_all.d
+++ b/create_dmd_release/build_all.d
@@ -30,7 +30,7 @@ enum linux_both = Platform(OS.linux, Model._both);
 /// OSes that require licenses must be setup manually
 
 /// Name: create_dmd_release-osx
-/// Setup: Preparing OSX-10.8 box, https://gist.github.com/MartinNowak/8156507
+/// Setup: Preparing OSX-10.13 box, https://gist.github.com/ibuclaw/4272119259b835672962e2b07bc35cd3
 enum osx_64 = Platform(OS.osx, Model._64);
 
 /// Name: create_dmd_release-windows

--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -357,8 +357,6 @@ void buildAll(Bits bits, string branch)
         auto ltoOption = " ENABLE_LTO=0";
     else version (linux)
         auto ltoOption = " ENABLE_LTO=" ~ (bits == Bits.bits32 ? "0" : "1");
-    else version (OSX)
-        auto ltoOption = " ENABLE_LTO=0";
     else
         auto ltoOption = " ENABLE_LTO=1";
     auto latest = " LATEST="~branch;


### PR DESCRIPTION
The old release builds were being built on a 10.8 machine, I've now ported it across to a 10.13 machine.  Still old, but not so much so that we have to build differently to Linux/Windows anymore.