### PR TITLE
create_dmd_release: Use amd64_x86 cross-toolchain when building 32-bit on 64-bit hosts

### DIFF
--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -330,7 +330,10 @@ void buildAll(Bits bits, string branch)
         // Setup MSVC environment for x64/x86 native builds
         auto vcVars = quote(buildPath(environment["LDC_VSDIR"], `VC\Auxiliary\Build\vcvarsall.bat`));
         msvcVarsX64 = vcVars~" x64 && ";
-        msvcVarsX86 = vcVars~" x86 && ";
+        version (Win64)
+            msvcVarsX86 = vcVars~" amd64_x86 && ";
+        else
+            msvcVarsX86 = vcVars~" x86 && ";
         msvcVars = bits == Bits.bits64 ? msvcVarsX64 : msvcVarsX86;
     }
 


### PR DESCRIPTION
Otherwise dmd will pick the wrong C compiler when calling `cl.exe` for preprocessing for importC compilations.

Correct argument for vcvarsall.bat determined by inspecting how vsoptions picks which compiler to preprocess with under what host/target combination.
https://github.com/dlang/dmd/blob/61d7d56a0b82e049f45758bf3b4449fddda2cf96/compiler/src/dmd/vsoptions.d#L384-L404