### PR TITLE
merge stable

### DIFF
--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -8,9 +8,10 @@ Prerequisites to Run:
 - Git
 - Posix: Working gcc toolchain, including GNU make which is not installed on
   FreeBSD by default. On OSX, you can install the gcc toolchain through Xcode.
-- Windows: Working DMC (incl. implib.exe) and 32/64-bit MSVC toolchains.
-  The default make must be DM make, and dmc.exe, DM lib.exe and implib.exe must be
-  found in PATH, so it's recommended to set the DMC bin dir as *first* dir in PATH.
+- Windows: Working DMC (incl. sppn.exe and implib.exe) and 32/64-bit MSVC
+  toolchains. The default make must be DM make, and dmc.exe, DM lib.exe,
+  sppn.exe and implib.exe must be found in PATH, so it's recommended to set the
+  DMC bin dir as *first* dir in PATH.
   Also, this environment variable must be set:
     LDC_VSDIR: Visual Studio directory containing the MSVC toolchains
   Examples:
@@ -329,7 +330,10 @@ void buildAll(Bits bits, string branch)
         // Setup MSVC environment for x64/x86 native builds
         auto vcVars = quote(buildPath(environment["LDC_VSDIR"], `VC\Auxiliary\Build\vcvarsall.bat`));
         msvcVarsX64 = vcVars~" x64 && ";
-        msvcVarsX86 = vcVars~" x86 && ";
+        version (Win64)
+            msvcVarsX86 = vcVars~" amd64_x86 && ";
+        else
+            msvcVarsX86 = vcVars~" x86 && ";
         msvcVars = bits == Bits.bits64 ? msvcVarsX64 : msvcVarsX86;
     }
 
@@ -357,8 +361,6 @@ void buildAll(Bits bits, string branch)
         auto ltoOption = " ENABLE_LTO=0";
     else version (linux)
         auto ltoOption = " ENABLE_LTO=" ~ (bits == Bits.bits32 ? "0" : "1");
-    else version (OSX)
-        auto ltoOption = " ENABLE_LTO=0";
     else
         auto ltoOption = " ENABLE_LTO=1";
     auto latest = " LATEST="~branch;

--- a/linux/dmd_deb.sh
+++ b/linux/dmd_deb.sh
@@ -275,7 +275,7 @@ else
 
 	# generate copyright file
 	mkdir -p usr/share/doc/dmd
-	for I in ../$UNZIPDIR/license.txt ../$UNZIPDIR/src/druntime/LICENSE.txt
+	for I in ../$UNZIPDIR/license.txt
 	do
 		sed 's/\r//;s/^[ \t]\+$//;s/^$/./;s/^/ /' $I > $I"_tmp"
 		if [ $(sed -n '/====/=' $I"_tmp") ]
@@ -289,7 +289,7 @@ else
 
 	Files: usr/bin/*
 	Copyright: 1999-'$(date +%Y)' by Digital Mars written by Walter Bright
-	License: Digital Mars License
+	License: Boost License 1.0
 
 	Files: usr/lib/*
 	Copyright: 1999-'$(date +%Y)' by Digital Mars written by Walter Bright
@@ -299,11 +299,8 @@ else
 	Copyright: 1999-'$(date +%Y)' by Digital Mars written by Walter Bright
 	License: Boost License 1.0
 
-	License: Digital Mars License' | sed 's/^\t//' > usr/share/doc/dmd/copyright
-	cat ../$UNZIPDIR/license.txt_tmp >> usr/share/doc/dmd/copyright
-	echo '
 	License: Boost License 1.0' | sed 's/^\t//' >> usr/share/doc/dmd/copyright
-	cat ../$UNZIPDIR/src/druntime/LICENSE.txt_tmp >> usr/share/doc/dmd/copyright
+	cat ../$UNZIPDIR/license.txt_tmp >> usr/share/doc/dmd/copyright
 
 
 	# create shlibs file

--- a/linux/dmd_phobos.sh
+++ b/linux/dmd_phobos.sh
@@ -177,7 +177,7 @@ else
 
 	# generate copyright file
 	mkdir -p usr/share/doc/$PHOBOSPKG
-	I="../$UNZIPDIR/src/druntime/LICENSE.txt"
+	I="../$UNZIPDIR/src/phobos/LICENSE_1_0.txt"
 	sed 's/\r//;s/^[ \t]\+$//;s/^$/./;s/^/ /' $I > $I"_tmp"
 	if [ $(sed -n '/====/=' $I"_tmp") ]
 	then
@@ -190,7 +190,7 @@ else
 	Files: usr/lib/*
 	Copyright: 1999-'$(date +%Y)' by Digital Mars written by Walter Bright
 	License: Boost License 1.0' | sed 's/^\t//' > usr/share/doc/$PHOBOSPKG/copyright
-	cat ../$UNZIPDIR/src/druntime/LICENSE.txt_tmp >> usr/share/doc/$PHOBOSPKG/copyright
+	cat ../$UNZIPDIR/src/phobos/LICENSE_1_0.txt_tmp >> usr/share/doc/$PHOBOSPKG/copyright
 
 
 	# create changelog

--- a/test/installation.sh
+++ b/test/installation.sh
@@ -18,9 +18,9 @@ RPM="dmd-${VERSION/-/\~}-0.fedora.x86_64.rpm"
 # dmd-2.079.1-0.openSUSE.x86_64.rpm, dmd-2.079.1~beta.1-0.openSUSE.x86_64.rpm
 SUSE_RPM="dmd-${VERSION/-/\~}-0.openSUSE.x86_64.rpm"
 
-DEB_PLATFORMS=(ubuntu:xenial ubuntu:bionic ubuntu:focal)
-DEB_PLATFORMS+=(debian:stable debian:testing)
-RPM_PLATFORMS=(fedora:31 fedora:latest centos:7 centos:latest)
+DEB_PLATFORMS=(ubuntu:xenial ubuntu:bionic ubuntu:focal ubuntu:jammy ubuntu:latest)
+DEB_PLATFORMS+=(debian:stable debian:testing debian:latest)
+RPM_PLATFORMS=(fedora:31 fedora:latest centos:7 quay.io/centos/centos:stream)
 SUSE_RPM_PLATFORMS=(opensuse/leap opensuse/tumbleweed)
 
 # copy pkgs to test folder so that it's part of docker's build context
@@ -107,8 +107,8 @@ set -euo pipefail
 trap 'echo -e "\e[1;31mInner script failed at line \$LINENO.\e[0m"' ERR
 set -x
 
-zypper --quiet --non-interactive removerepo 'NON OSS'
-zypper --quiet --non-interactive install curl >/dev/null
+zypper --quiet --non-interactive removerepo repo-non-oss repo-update-non-oss
+zypper --quiet --non-interactive install curl findutils >/dev/null
 zypper --quiet --non-interactive --no-gpg-checks install $SUSE_RPM >/dev/null
 curl --version >/dev/null
 # run a complex D hello world (using libcurl)


### PR DESCRIPTION
- fix copying linux packages
- disable codesigning by default for now
- fixup ee0c33dddc - conditional codesign
- workaround dated OSX sshd host key algos
- scp with OSX requires target folders to exist before recursive copy
- temporarily disable LTO on OSX to workaround dated linker
- bump memory to build dub
- build_all.d: Update instructions for building linux vagrant box
- linux: Fix license paths in deb package scripts
- create_dmd_release.d: Update instructions for creating release in windows environment
- Remove workarounds for old OSX release image
- build_all.d: Update instructions for building osx vagrant box
- create_dmd_release: Use amd64_x86 cross-toolchain when building 32-bit on 64-bit hosts
- test: Add ubuntu:jammy to list of deb platforms
- test: Add ubuntu:latest and debian:latest
- test: Replace centos:latest with centos:stream
- test: Fix preinstall steps of openSUSE tests
