### PR TITLE
Build the Linux release on Ubuntu 20.04

### DIFF
--- a/.github/workflows/build_release_template.yml
+++ b/.github/workflows/build_release_template.yml
@@ -124,7 +124,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             target: linux
           - os: macos-latest
             target: osx


### PR DESCRIPTION
Building on ubuntu-latest may result in more recent libraries being linked in. E.g. currently dub nightly build fails to run dub-master because it depends on glibc 2.32+ while ubuntu-20.04 only has 2.31.