### PR TITLE
ci: Update cirrus macOS image to macos-monterey-xcode

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -37,12 +37,11 @@ task:
 # OSX
 task:
   name: dlang.installer (osx)
-  osx_instance:
-    image: catalina-xcode
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-monterey-xcode:latest
   timeout_in: 60m
   environment:
     OS_NAME: osx
   install_gnupg_script: |
-    brew update-reset
     brew install gnupg
   test_installer_script: ./test/all.sh

--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -4,9 +4,15 @@ set -uexo pipefail
 
 ROOT=$(dirname $0)
 
+function awsb2
+{
+    region=$(aws --profile ddo configure list | awk '$1 == "region" { print $2 }')
+    aws --endpoint-url="https://s3.${region}.backblazeb2.com" $@
+}
+
 rm -f $ROOT/install.sh.sig
 ${GPG:-gpg2} --detach-sign $ROOT/install.sh
 
 scp "$ROOT/install.sh" "$ROOT/install.sh.sig" digitalmars.com:/usr/local/www/dlang.org/data/
-aws --profile ddo s3 cp "$ROOT/install.sh" s3://downloads.dlang.org/other/ --acl public-read --cache-control max-age=604800
-aws --profile ddo s3 cp "$ROOT/install.sh.sig" s3://downloads.dlang.org/other/ --acl public-read --cache-control max-age=604800
+awsb2 --profile ddo s3 cp "$ROOT/install.sh" s3://downloads-dlang-org/other/ --acl public-read --cache-control max-age=604800
+awsb2 --profile ddo s3 cp "$ROOT/install.sh.sig" s3://downloads-dlang-org/other/ --acl public-read --cache-control max-age=604800

--- a/test/common.sh
+++ b/test/common.sh
@@ -4,6 +4,11 @@ set -eu -o pipefail
 
 ROOT="$DIR/../"
 INSTALLER="$ROOT/script/install.sh"
+INSTALLER_ARGS=""
+if [ "${OS_NAME}" == "osx" ] ; then
+    INSTALLER_ARGS="--arch x86_64"
+fi
+
 
 assert() {
     actual="$1"

--- a/test/t/base.sh
+++ b/test/t/base.sh
@@ -2,43 +2,79 @@
 
 set -uexo pipefail
 
-compilers=(
-    dmd-2.088.1
-    dmd-2.094.2
-    dmd-2.097.2
-    dmd-master-2020-03-10
-    ldc-1.18.0
-)
-
-versions=(
-    'DMD64 D Compiler v2.088.1'
-    'DMD64 D Compiler v2.094.2'
-    'DMD64 D Compiler v2.097.2'
-    'DMD64 D Compiler v2.091.0-beta.2-master-ec39fe5'
-    'LDC - the LLVM D compiler (1.18.0):'
-)
-
-frontendVersions=(
-    '2088'
-    '2094'
-    '2097'
-    '2091'
-    '2088'
-)
-
 if [ "${OS_NAME:-}" = "linux" ]; then
-    compilers+=(
+    compilers=(
+        dmd-2.088.1
+        dmd-2.094.2
+        dmd-2.097.2
+        dmd-master-2020-03-10
+        ldc-1.18.0
         gdc-4.9.3
         gdc-4.8.5
     )
 
-    versions+=(
+    versions=(
+        'DMD64 D Compiler v2.088.1'
+        'DMD64 D Compiler v2.094.2'
+        'DMD64 D Compiler v2.097.2'
+        'DMD64 D Compiler v2.091.0-beta.2-master-ec39fe5'
+        'LDC - the LLVM D compiler (1.18.0):'
         'gdc (crosstool-NG crosstool-ng-1.20.0-232-gc746732 - 20150825-2.066.1-58ec4c13ec) 4.9.3'
         'gdc (gdcproject.org 20161225-v2.068.2_gcc4.8) 4.8.5'
     )
-    frontendVersions+=(
+    frontendVersions=(
+        '2088'
+        '2094'
+        '2097'
+        '2091'
+        '2088'
         '2066'
         '2068'
+    )
+elif [ "${OS_NAME:-}" = "osx" ]; then
+    # Since macOS 12.x, versions of DMD older than 2.099.1 do not work.
+    # https://github.com/dlang/dmd/pull/13890
+    compilers=(
+        dmd-2.099.1
+        dmd-2.100.0
+        dmd-2.101.2
+        ldc-1.30.0
+    )
+
+    versions=(
+        'DMD64 D Compiler v2.099.1'
+        'DMD64 D Compiler v2.100.0'
+        'DMD64 D Compiler v2.101.2'
+        'LDC - the LLVM D compiler (1.30.0):'
+    )
+    frontendVersions=(
+        '2099'
+        '2100'
+        '2101'
+        '2100'
+    )
+else
+    compilers=(
+        dmd-2.088.1
+        dmd-2.094.2
+        dmd-2.097.2
+        dmd-master-2020-03-10
+        ldc-1.18.0
+    )
+
+    versions=(
+        'DMD64 D Compiler v2.088.1'
+        'DMD64 D Compiler v2.094.2'
+        'DMD64 D Compiler v2.097.2'
+        'DMD64 D Compiler v2.091.0-beta.2-master-ec39fe5'
+        'LDC - the LLVM D compiler (1.18.0):'
+    )
+    frontendVersions=(
+        '2088'
+        '2094'
+        '2097'
+        '2091'
+        '2088'
     )
 fi
 

--- a/test/t/dub.sh
+++ b/test/t/dub.sh
@@ -26,7 +26,7 @@ do
     fi
 
     echo "Testing: $compiler"
-    "$INSTALLER" $compiler
+    "$INSTALLER" $INSTALLER_ARGS $compiler
     . $("$INSTALLER" $compiler -a)
 
     compilerVersion=$(dub --version | sed -n 1p | tr -d '\r')

--- a/test/t/where.sh
+++ b/test/t/where.sh
@@ -89,10 +89,10 @@ for idx in "${!compilers[@]}"
 do
     compiler="${compilers[$idx]}"
     echo "Testing: $compiler"
-    assert "$("$INSTALLER" get-path --dmd "$compiler" --install)" "${versions_dmd[$idx]}"
-    assert "$("$INSTALLER" get-path "$compiler" --dmd)" "${versions_dmd[$idx]}"
-    assert "$("$INSTALLER" get-path "$compiler")" "${versions_dc[$idx]}"
-    assert "$("$INSTALLER" get-path --dub "$compiler")" "${versions_dub[$idx]}"
+    assert "$("$INSTALLER" $INSTALLER_ARGS get-path --dmd "$compiler" --install)" "${versions_dmd[$idx]}"
+    assert "$("$INSTALLER" $INSTALLER_ARGS get-path "$compiler" --dmd)" "${versions_dmd[$idx]}"
+    assert "$("$INSTALLER" $INSTALLER_ARGS get-path "$compiler")" "${versions_dc[$idx]}"
+    assert "$("$INSTALLER" $INSTALLER_ARGS get-path --dub "$compiler")" "${versions_dub[$idx]}"
     $INSTALLER uninstall "$compiler"
 done
 
@@ -116,7 +116,7 @@ done
 ################################################################################
 # assert error without --install
 ################################################################################
-out=$(! "$INSTALLER" get-path dmd-2.077.0 2>&1)
+out=$(! "$INSTALLER" $INSTALLER_ARGS get-path dmd-2.077.0 2>&1)
 echo "$out" | grep -q "not installed"
 
 ################################################################################
@@ -125,7 +125,7 @@ echo "$out" | grep -q "not installed"
 
 $INSTALLER install dmd-2.066.0
 rm -rf ~/dlang/dub # manually uninstall dub
-out=$(! "$INSTALLER" get-path --dub dmd-2.066.0 2>&1)
+out=$(! "$INSTALLER" $INSTALLER_ARGS get-path --dub dmd-2.066.0 2>&1)
 echo "$out" | grep -q "DUB is not installed"
 $INSTALLER uninstall dmd-2.066.0
 
@@ -135,30 +135,30 @@ $INSTALLER uninstall dmd-2.066.0
 
 # check errors if dub is installed
 $INSTALLER uninstall dub-1.22.0 || echo "dub-1.22.0 wasn't installed"
-out=$(! "$INSTALLER" get-path dub-1.22.0 2>&1)
+out=$(! "$INSTALLER" $INSTALLER_ARGS get-path dub-1.22.0 2>&1)
 echo "$out" | grep -q "not installed"
 
-out=$(! "$INSTALLER" get-path --dmd dub-1.22.0 2>&1)
+out=$(! "$INSTALLER" $INSTALLER_ARGS get-path --dmd dub-1.22.0 2>&1)
 echo "$out" | grep -q "not installed"
 
-out=$(! "$INSTALLER" get-path dub-1.22.0 --dub 2>&1)
+out=$(! "$INSTALLER" $INSTALLER_ARGS get-path dub-1.22.0 --dub 2>&1)
 echo "$out" | grep -q "not installed"
 
 # dmd is installed, but not dub
 $INSTALLER install dmd-2.079.0
-out=$(! "$INSTALLER" get-path dmd-2.079.0,dub-1.22.0 --dub 2>&1)
+out=$(! "$INSTALLER" $INSTALLER_ARGS get-path dmd-2.079.0,dub-1.22.0 --dub 2>&1)
 echo "$out" | grep -q "not installed"
 $INSTALLER uninstall dmd-2.079.0
 
 # errors when requesting a compiler with dub
-out=$(! "$INSTALLER" get-path --install dub-1.22.0 2>&1 | tail -n1)
+out=$(! "$INSTALLER" $INSTALLER_ARGS get-path --install dub-1.22.0 2>&1 | tail -n1)
 assert "$out" "ERROR: DUB is not a compiler."
 
-out=$(! "$INSTALLER" get-path --dmd dub-1.22.0 2>&1)
+out=$(! "$INSTALLER" $INSTALLER_ARGS get-path --dmd dub-1.22.0 2>&1)
 assert "$out" "ERROR: DUB is not a compiler."
 
 # dub with --dub
-out=$("$INSTALLER" get-path dub-1.22.0 --dub 2>&1)
+out=$("$INSTALLER" $INSTALLER_ARGS get-path dub-1.22.0 --dub 2>&1)
 assert "$out" "$ROOT/dub-1.22.0/dub"
 
 $INSTALLER uninstall dub-1.22.0


### PR DESCRIPTION
We seem to have missed the memo saying that the Intel-based runners will be removed from 1st Jan 2023, no idea if we are even ready to run on M1 hosts?

https://cirrus-ci.org/blog/2022/11/08/sunsetting-intel-macos-instances/