### PR TITLE
merge stable

### DIFF
--- a/changelog/VisualDUpdate.dd
+++ b/changelog/VisualDUpdate.dd
@@ -1,0 +1,5 @@
+Update the bundled VisualD package
+
+The $(LINK2 https://rainers.github.io/visuald/visuald/StartPage.html, VisualD) package version
+that the installer downloads hasn't been updated in years. This has been remedied by a version
+bump to 1.3.1, the latest release of VisualD.

--- a/changelog/issue_23623.dd
+++ b/changelog/issue_23623.dd
@@ -1,0 +1,5 @@
+Prefer 64 bit over 32 bit DMD on Windows 64 bit.
+
+The NSIS installer for Windows has the option "Add to PATH". Previously, only
+the 32 bit version of DMD was added to the PATH environment variable. Now, on
+Windows 64 bit, the 64 bit version of DMD will be selected from PATH.

--- a/windows/d2-installer.nsi
+++ b/windows/d2-installer.nsi
@@ -39,7 +39,7 @@
 ; Routinely Update
 ; ----------------
 ; Visual D
-!define VersionVisualD "0.50.1"
+!define VersionVisualD "1.3.1"
 
 ; DMC
 !define VersionDMC "857"
@@ -106,6 +106,8 @@ Unicode True
 !include "FileFunc.nsh"
 !include "TextFunc.nsh"
 !include "Sections.nsh"
+!include "LogicLib.nsh"
+!include "x64.nsh"
 
 ;------------------------------------------------------------
 ; Variables
@@ -294,6 +296,9 @@ SectionGroup /e "D2"
 
 
   Section "Add to PATH" AddD2ToPath
+    ${If} ${RunningX64}
+      ${EnvVarUpdate} $0 "PATH" "A" "HKLM" "$INSTDIR\dmd2\windows\bin64"
+    ${EndIf}
     ${EnvVarUpdate} $0 "PATH" "A" "HKLM" "$INSTDIR\dmd2\windows\bin"
   SectionEnd
 
@@ -544,6 +549,7 @@ FunctionEnd
 
 Section "Uninstall"
   ; Remove directories from PATH (for all users)
+  ${un.EnvVarUpdate} $0 "PATH" "R" "HKLM" "$INSTDIR\dmd2\windows\bin64"
   ${un.EnvVarUpdate} $0 "PATH" "R" "HKLM" "$INSTDIR\dmd2\windows\bin"
 
   ; Remove stuff from registry


### PR DESCRIPTION
- script/deploy.sh: Replace aws command with awsb2
- test/t/base.sh: Only test from 2.099.1 onwards on macOS
- test/common.sh: Include '--arch x86_64' when running installer on macOS
- ci: Update cirrus macOS image to macos-monterey-xcode
- Nobody has routinely updated Visual D for 3 years
- Add changelog entry
- fix Issue 23623 - Prefer 64 bit over 32 bit DMD on Windows 64 bit.
