### PR TITLE
test: Don't complain if .dub directory doesn't exist

### DIFF
--- a/test/release/validate_release.sh
+++ b/test/release/validate_release.sh
@@ -62,7 +62,7 @@ done
 for DUB in $GEN/dmd2/$OS/bin*/dub$EXE
 do
 	$DUB run -n --arch=x86_64 --single $DIR/dub_example.d
-	rm -r $DIR/.dub $DIR/dub_example$EXE
+	rm -rf $DIR/.dub $DIR/dub_example$EXE
 done
 
 ###############################################################################


### PR DESCRIPTION
As I understand, dub now has a more central build/cache location.  This just paints over the problem, but would keep compat with old and new behaviour.