### PR TITLE
Adapt to generic Makefiles

### DIFF
--- a/.github/workflows/build_release_template.yml
+++ b/.github/workflows/build_release_template.yml
@@ -85,7 +85,7 @@ jobs:
           N=$(( 2 * $(nproc) ))
 
           # Build minimal host compiler (sometimes not triggered by dlang.org/posix.mak)
-          make -f posix.mak -j$N -C dmd/druntime
+          make -j$N -C dmd
 
           # Build docs and include the man pages
           make -f posix.mak -j$N -C dlang.org release

--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -6,8 +6,6 @@ name: test_release
 on:
   pull_request:
   push:
-    branches:
-      - master
 
 jobs:
   build_release:

--- a/create_dmd_release/build_all.d
+++ b/create_dmd_release/build_all.d
@@ -459,7 +459,7 @@ void cloneSources(string gitTag, string dubTag, bool isBranch, bool skipDocs, st
             run(fmt.format(gitTag, proj));
     }
     enforce(nfallback < allProjects.length, "Branch " ~ gitTag ~ " not found in any dlang repo.");
-    run(fmt.format(dubTag, "dub"));
+    run(fmt.format(isBranch && !branchExists(prefix ~ "dub", dubTag) ? "master" : dubTag, "dub"));
 }
 
 bool branchExists(string gitRepo, string branch)

--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -417,21 +417,10 @@ void buildAll(Bits bits, string branch)
         info("Building Dub "~bitsDisplay);
         changeDir(cloneDir~"/dub");
 
-        if (exists("build.d"))
-        {
-            // v1.20+
-            version (Windows)
-                run(msvcVars~"SET DMD="~hostDMD~" && "~hostDMD~" -m"~bitsStr~" -run build.d -O -w -m"~bitsStr);
-            else
-                run("DMD="~hostDMD~" "~hostDMD~" -run build.d -O -w -m"~bitsStr);
-        }
+        version (Windows)
+            run(msvcVars~"set DMD="~hostDMD~"&& "~hostDMD~" -m"~bitsStr~" -run build.d -O -w -m"~bitsStr);
         else
-        {
-            version (Windows)
-                run(msvcVars~"SET DC="~hostDMD~" && build.cmd -m"~bitsStr); // TODO: replace DC with DMD
-            else
-                run("DMD="~hostDMD~" ./build.sh -m"~bitsStr);
-        }
+            run("DMD="~hostDMD~" "~hostDMD~" -run build.d -O -w -m"~bitsStr);
         rename(cloneDir~"/dub/bin/dub"~exe, cloneDir~"/dub/bin/dub"~bitsStr~exe);
     }
 }

--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -85,7 +85,6 @@ version(Windows)
     immutable dll           = ".dll";
     immutable libPhobos32   = "phobos";
     immutable libPhobos64   = "phobos64";
-    immutable build64BitTools = false;
 
     immutable osDirName     = "windows";
     immutable make          = "mingw32-make";
@@ -100,7 +99,6 @@ else version(Posix)
     immutable obj           = ".o";
     immutable libPhobos32   = "libphobos2";
     immutable libPhobos64   = "libphobos2";
-    immutable build64BitTools    = true;
 
     version(FreeBSD)
         immutable osDirName = "freebsd";
@@ -401,7 +399,6 @@ void buildAll(Bits bits, string branch)
         }
     }
 
-    if(build64BitTools || is32)
     {
         // Build the tools using the host compiler
         auto tools_makecmd = makecmd.replace(dmdEnv, " DMD=" ~ hostDMD);
@@ -414,8 +411,6 @@ void buildAll(Bits bits, string branch)
         run(tools_makecmd~" rdmd ddemangle dustmite");
     }
 
-    bool buildDub = true; // build64BitTools || is32;
-    if(buildDub)
     {
         // build dub with stable (host) compiler, b/c it breaks
         // too easily with the latest compiler, e.g. for nightlies
@@ -560,10 +555,7 @@ void createRelease(string branch)
             sc_ini = sc_ini.replace(`%@P%\optlink.exe`, `%@P%\..\bin\optlink.exe`);
             std.file.write(releaseBin64Dir~"/sc.ini", sc_ini);
         }
-        else // Win doesn't include 64-bit tools
-        {
-            copyDir(cloneDir~"/tools/generated/"~osDirName~"/64", releaseBin64Dir, file => !file.endsWith(obj));
-        }
+        copyDir(cloneDir~"/tools/generated/"~osDirName~"/64", releaseBin64Dir, file => !file.endsWith(obj));
         copyFile(cloneDir~"/dub/bin/dub64"~exe, releaseBin64Dir~"/dub"~exe);
         if (codesign)
             signBinaries(releaseBin64Dir);


### PR DESCRIPTION
Depends on
* https://github.com/dlang/dmd/pull/15894 and https://github.com/dlang/dmd/pull/15920
* https://github.com/dlang/phobos/pull/8862
* https://github.com/dlang/tools/pull/465

Soft depends on
* https://github.com/dlang/installer/pull/566 

The Windows VM used for the releases needs a GNU make; `mingw32-make.exe` is available for CI (the first `make.exe` in PATH there is DigitalMars make), so I went with that for now. FWIW, I've just seen that GNU make can also be installed via Chocolatey (`choco install make`).