### PR TITLE
Fix Issue 22212 - dmd version has -dirty suffix on windows

### DIFF
--- a/create_dmd_release/create_dmd_release.d
+++ b/create_dmd_release/create_dmd_release.d
@@ -298,14 +298,20 @@ void cleanAll(string branch)
     changeDir(cloneDir~"/dmd");
     run("git clean -f -x -d"); // remove all untracked/ignored files
     run("git checkout ."); // undo local changes, e.g. VERSION
+    version (Windows)
+        run("git config core.fileMode false"); // ignore executable bit of files
 
     info("Cleaning Phobos");
     changeDir(cloneDir~"/phobos");
     run("git clean -f -x -d");
+    version (Windows)
+        run("git config core.fileMode false");
 
     info("Cleaning Tools");
     changeDir(cloneDir~"/tools");
     run("git clean -f -x -d");
+    version (Windows)
+        run("git config core.fileMode false");
 }
 
 void buildAll(string branch)


### PR DESCRIPTION
Typically, git-clone probes the filesystem to see if it handles the executable bit correctly and the `core.fileMode` variable is automatically set as necessary. However when building dmd releases using vagrant box method, git-clone is done on a Linux host (i.e a filesystem that handles the filemode correctly), then scp'd to a Windows VM (i.e an environment that loses the filemode). So when building Windows binaries, always ensure this variable is set to `false`.