### PR TITLE
Bump FreeBSD to 13.2

### DIFF
--- a/.github/workflows/build_release_template.yml
+++ b/.github/workflows/build_release_template.yml
@@ -266,12 +266,12 @@ jobs:
       #
       - name: Run build_all.d for FreeBSD in a dedicated VM
         if: matrix.target == 'freebsd'
-        uses: cross-platform-actions/action@v0.21.1
+        uses: cross-platform-actions/action@v0.22.0
         with:
           operating_system: freebsd
           hypervisor: qemu
           memory: 8G
-          version: '12.2'
+          version: '13.2'
           shell: bash
           run: |
             set -eux


### PR DESCRIPTION
The DMD nightly build for FreeBSD fails since two weeks, because the old version is not available anymore. As a result the nightly builds for other platforms are also not uploaded.

This increases the versions for FreeBSD the same as in https://github.com/dlang/dmd/pull/15979, but I have not tested it.