### PR TITLE
GHA: Replace deprecated set-output

### DIFF
--- a/.github/workflows/build_release_template.yml
+++ b/.github/workflows/build_release_template.yml
@@ -109,7 +109,7 @@ jobs:
           for REPO in dmd phobos
           do
             REV=$( git -C $REPO rev-parse HEAD )
-            echo "::set-output name=$REPO-revision::$REV"
+            echo "$REPO-revision=$REV" >> $GITHUB_OUTPUT
           done
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This should fix a warning for the nightly builds in bugzilla issue 24600.