### PR TITLE
CI: Rename Windows installer artifacts to dmd-<branch>.exe

### DIFF
--- a/.github/workflows/build_release_template.yml
+++ b/.github/workflows/build_release_template.yml
@@ -252,6 +252,7 @@ jobs:
           for /f %%v in (dmd.windows\dmd2\src\VERSION) do set ver=%%v
           cd windows || exit /b
           "c:\Program Files (x86)\NSIS\makensis" /DVersion2=%ver% /DEmbedD2Dir=..\dmd.windows\dmd2 d2-installer.nsi || exit /b
+          ren dmd-%ver%.exe dmd-${{ inputs.release_branch }}.exe || exit /b
           copy dmd-*.exe ..\create_dmd_release\build || exit /b
 
       #################################################################


### PR DESCRIPTION
Don't use the DMD `VERSION` file, currently leading to names like `dmd-v2.110.0-beta.1.exe`, which accumulate for the nightly release: https://github.com/dlang/dmd/releases/tag/nightly

Switch to `dmd-master.exe`, similar to the other artifact names.