### PR TITLE
improve VS installation page

### DIFF
--- a/windows/d2-installer.nsi
+++ b/windows/d2-installer.nsi
@@ -52,6 +52,7 @@
 !define VS2019BTFilename "vs_BuildTools2019.exe"
 !define VCRedistx86Filename "vcredist_x86.exe"
 !define VCRedistx64Filename "vcredist_x64.exe"
+!define VS2022Filename "vs_community2022.exe"
 
 ; URLs
 !define VisualDBaseURL "https://github.com/dlang/visuald/releases/download"
@@ -63,6 +64,7 @@
 !define VS2017BuildToolsUrl "https://download.visualstudio.microsoft.com/download/pr/100404314/e64d79b40219aea618ce2fe10ebd5f0d/vs_BuildTools.exe"
 !define VS2019Url "https://download.visualstudio.microsoft.com/download/pr/8ab6eab3-e151-4f4d-9ca5-07f8434e46bb/8cc1a4ebd138b5d0c2b97501a198f5eacdc434daa8a5c6564c8e23fdaaad3619/vs_Community.exe"
 !define VS2019BuildToolsUrl "https://download.visualstudio.microsoft.com/download/pr/8ab6eab3-e151-4f4d-9ca5-07f8434e46bb/cfffd18469d936d6cb9dff55fd4ae538035e7f247f1756c5a31f3e03751d7ee7/vs_BuildTools.exe"
+!define VS2022Url "https://c2rsetup.officeapps.live.com/c2r/downloadVS.aspx?sku=community&channel=Release&version=VS2022"
 
 ; see https://stackoverflow.com/questions/12206314/detect-if-visual-c-redistributable-for-visual-studio-2012-is-installed/14878248
 ; selecting VC2010
@@ -210,8 +212,8 @@ SetCompressorDictSize 112
 !define MUI_WELCOMEFINISHPAGE_BITMAP "d2-installer-image.bmp"
 !insertmacro MUI_PAGE_WELCOME
 !insertmacro MUI_PAGE_COMPONENTS
-!insertmacro MUI_PAGE_DIRECTORY
 Page custom VCInstallPage VCInstallPageValidate
+!insertmacro MUI_PAGE_DIRECTORY
 !insertmacro MUI_PAGE_INSTFILES
 !insertmacro MUI_PAGE_FINISH
 
@@ -330,7 +332,7 @@ FunctionEnd
 Function VCInstallPageValidate
 
   !insertmacro MUI_INSTALLOPTIONS_READ $0 "vcinstall.ini" "Field 2" "State"
-  StrCmp $0 1 install_vs2013
+  StrCmp $0 1 install_vs2022
   !insertmacro MUI_INSTALLOPTIONS_READ $0 "vcinstall.ini" "Field 3" "State"
   StrCmp $0 1 install_vs2019
   !insertmacro MUI_INSTALLOPTIONS_READ $0 "vcinstall.ini" "Field 4" "State"
@@ -339,21 +341,29 @@ Function VCInstallPageValidate
   StrCmp $0 1 install_vc2010
   goto done_vc
 
-  install_vs2013:
-    !insertmacro DownloadAndRun ${VS2013Filename} ${VS2013Url} ""
-    goto done_vc
+  install_vs2022:
+    ; check whether installed externally
+    Call DetectVC
+    StrCmp $VCVer "" 0 done_vc
+    !insertmacro DownloadAndRun ${VS2022Filename} ${VS2022Url} ""
+    goto check_vc
 
   install_vs2019:
     !insertmacro DownloadAndRun ${VS2019Filename} ${VS2019Url} ""
-    goto done_vc
+    goto check_vc
 
   install_bt2019:
     !insertmacro DownloadAndRun ${VS2019BTFilename} ${VS2019BuildToolsUrl} ""
-    goto done_vc
+    goto check_vc
 
   install_vc2010:
     Call InstallVCRedistributable
     goto done_vc
+
+  check_vc:
+    Call DetectVC
+    StrCmp $VCVer "" 0 done_vc
+    Abort
 
   done_vc:
 

--- a/windows/vcinstall.ini
+++ b/windows/vcinstall.ini
@@ -1,5 +1,5 @@
 [Settings]
-NumFields=7
+NumFields=9
 
 [Field 1]
 Type=Groupbox
@@ -12,8 +12,8 @@ Bottom=136
 
 [Field 2]
 Type=RadioButton
-Text=Download and install Visual Studio 2013
-State=0
+Text=Download and install Visual Studio 2022 Community or select your
+State=1
 Left=20
 Right=300
 Top=48
@@ -21,12 +21,12 @@ Bottom=60
 
 [Field 3]
 Type=RadioButton
-Text=Download and install Visual Studio 2019
-State=1
+Text=Download and install Visual Studio 2019 Community
+State=0
 Left=20
 Right=300
-Top=64
-Bottom=76
+Top=74
+Bottom=86
 
 [Field 4]
 Type=RadioButton
@@ -34,8 +34,8 @@ Text=Download and install Build Tools for Visual Studio 2019
 State=0
 Left=20
 Right=300
-Top=80
-Bottom=94
+Top=88
+Bottom=100
 
 [Field 5]
 Type=RadioButton
@@ -43,8 +43,8 @@ Text=Install VC2010 redistributables to use it with MinGW Platform libraries
 State=0
 Left=20
 Right=300
-Top=98
-Bottom=112
+Top=102
+Bottom=114
 
 [Field 6]
 Type=RadioButton
@@ -53,12 +53,29 @@ State=0
 Left=20
 Right=300
 Top=116
-Bottom=130
+Bottom=128
 
 [Field 7]
 Type=Label
-Text=No Visual Studio Installation was found on your system. To build 64-bit programs or 32-bit programs targeting the VC runtime, you need to install one of the options below.
+Text=No Visual C installation was found on your system. Building D programs usually requires the Microsoft linker and the VC runtime library, you should install one of the options below. Make sure to select the C++ environment during installation.
 Left=0
 Right=300
 Top=0
 Bottom=36
+
+[Field 8]
+Type=Label
+Text=preferred version from
+Left=40
+Right=120
+Top=60
+Bottom=72
+
+[Field 9]
+Type=Link
+Text=https://visualstudio.microsoft.com/downloads/
+State=https://visualstudio.microsoft.com/downloads/
+Left=120
+Right=300
+Top=60
+Bottom=72


### PR DESCRIPTION
- move before installation directory selection so that installation doesn't automatically start after a (canceled) VS download/install
- verify installation after download+install, only continue to next page if successful or "do nothing is selected"
- replace VS 2013 install with VS 2022 and make it the default (I don't remember what was so special about 2013 to keep it so far).
- reword the intro

now looks like this:
![image](https://github.com/user-attachments/assets/b969a77b-e4f1-415d-96c2-fbccc727d5d0)
