### PR TITLE
Update Visual D version to v1.4.1

### DIFF
--- a/windows/d2-installer-descriptions.nsh
+++ b/windows/d2-installer-descriptions.nsh
@@ -7,7 +7,7 @@ LangString DESC_Dmd2Files ${LANG_ENGLISH} "Digital Mars D version 2 compiler"
 LangString DESC_SMShortcuts ${LANG_ENGLISH} "Add Shortcuts to the Start Menu to start the command interpreter with adjusted environment"
 LangString DESC_AddD2ToPath ${LANG_ENGLISH} "Modify the PATH environment variable so DMD can be used from any command prompt"
 
-LangString DESC_VisualDDownload ${LANG_ENGLISH} "Visual Studio package providing both project management and language services. It works with Visual Studio 2008-2017 (and the free VS Shells)"
+LangString DESC_VisualDDownload ${LANG_ENGLISH} "Visual Studio package providing project management, language services and debugger support. It works with Visual Studio 2008-2022"
 
 
 ; Shortcuts

--- a/windows/d2-installer.nsi
+++ b/windows/d2-installer.nsi
@@ -39,7 +39,7 @@
 ; Routinely Update
 ; ----------------
 ; Visual D
-!define VersionVisualD "1.3.1"
+!define VersionVisualD "1.4.1"
 
 ; Update Rarely Needed
 ; --------------------


### PR DESCRIPTION
Unfortunately v1.4.0 is often quarantined by Windows Defender since a couple of weeks ago, so I just released v1.4.1 which is digitally signed (with the expired certificate, but still seems to help a bit).