### PR TITLE
build_all.d: Handle quoted/glob source locations when NoVagrant

### DIFF
--- a/create_dmd_release/build_all.d
+++ b/create_dmd_release/build_all.d
@@ -138,6 +138,8 @@ struct Box
         {
             if (src.startsWith("default:"))
                 src = _tmpdir ~ "/" ~ src[8..$];
+            else if (src.startsWith("'default:"))
+                src = "'" ~ _tmpdir ~ "/" ~ src[9..$];
             if (tgt.startsWith("default:"))
                 tgt = _tmpdir ~ "/" ~ tgt[8..$];
 


### PR DESCRIPTION
Correctly handle the following scp calls on Linux
```
box.scp("'default:clones/installer/linux/*.deb'", "build/");
box.scp("'default:clones/installer/linux/*.rpm'", "build/");
```
And on OSX
```
box.scp("'default:clones/installer/osx/*.dmg'", "build/");
```

@dkorpel 

