### PR TITLE
build_release_template.yml: Chomp the prefixing 'v' from the release branch

### DIFF
--- a/.github/workflows/build_release_template.yml
+++ b/.github/workflows/build_release_template.yml
@@ -248,14 +248,17 @@ jobs:
           7z x inetc.zip -y -bb1 "-oc:\Program Files (x86)\NSIS" || exit /b
 
           :: unpack release .7z generated in previous step
-          7z x create_dmd_release\build\dmd.${{ inputs.release_branch }}.windows.7z -odmd.windows || exit /b
+          :: chomp off the "v" prefix if there is one, as this is what build_all does
+          set release=${{ inputs.release_branch }}
+          if "%release:~0,1%"=="v" set release=%release:~1%
+          7z x create_dmd_release\build\dmd.%release%.windows.7z -odmd.windows || exit /b
 
           @echo on
           "c:\Program Files (x86)\NSIS\makensis" /version
           for /f %%v in (dmd.windows\dmd2\src\VERSION) do set ver=%%v
           cd windows || exit /b
           "c:\Program Files (x86)\NSIS\makensis" /DVersion2=%ver% /DEmbedD2Dir=..\dmd.windows\dmd2 d2-installer.nsi || exit /b
-          ren dmd-%ver%.exe dmd-${{ inputs.release_branch }}.exe || exit /b
+          ren dmd-%ver%.exe dmd-%release%.exe || exit /b
           copy dmd-*.exe ..\create_dmd_release\build || exit /b
 
       #################################################################


### PR DESCRIPTION
Windows release build currently fails because the 7z file doesn't exist.
```
7-Zip 26.00 (x64) : Copyright (c) 1999-2026 Igor Pavlov : 2026-02-12

ERROR: The system cannot find the file specified.
create_dmd_release\build\dmd.v2.112.1-rc.1.windows.7z
```
This is because build_all calls `chompPrefix("v")` on the version string before using it in all archive names.
```
Copying file 'C:\Users\RUNNER~1\AppData\Local\Temp\tmp.8319A2/dmd.2.112.1-rc.1.windows.zip' to 'build/dmd.2.112.1-rc.1.windows.zip'.
Building LZMA archive 'build/dmd.2.112.1-rc.1.windows.7z'.
```

I don't understand batch script, so this may be completely off the mark.

@rainers ? @kinke ?