### PR TITLE
[stable] CI: Fix verification on FreeBSD by switching to the same FreeBSD version

### DIFF
--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -74,7 +74,7 @@ jobs:
           hypervisor: qemu
           memory: 12G
           cpu_count: 4
-          version: '12.2'
+          version: '13.2'
           environment_variables: OS BUILD
           shell: bash
           run: source ./installer/test/release/validate_release.sh


### PR DESCRIPTION
v13.2, as used for the build: https://github.com/dlang/installer/blob/40bc9ab20bae974653bb89ea534f30c75972d2d1/.github/workflows/build_release_template.yml#L275

This should fix this error (https://github.com/dlang/installer/actions/runs/22625401992/job/65562732407#step:5:101):
```
/home/runner/work/installer/installer/installer/test/release/generated/dmd2/freebsd/bin64/dmd --version
ld-elf.so.1: /lib/libc.so.7: version FBSD_1.7 required by /home/runner/work/installer/installer/installer/test/release/generated/dmd2/freebsd/bin64/dmd not found
```

FreeBSD 13 is the oldest still supported version ('legacy'): https://www.freebsd.org/releases/