### PR TITLE
Add phobos directory to Linux build scripts to ship Pv3 on Linux.

### DIFF
--- a/linux/dmd_deb.sh
+++ b/linux/dmd_deb.sh
@@ -207,7 +207,7 @@ else
 
 	# install include
 	mkdir -p usr/include/dmd/{phobos,druntime}
-	cp -Rf ../$UNZIPDIR/src/phobos/{std,etc} usr/include/dmd/phobos/
+	cp -Rf ../$UNZIPDIR/src/phobos/{std,etc,phobos} usr/include/dmd/phobos/
 	cp -Rf ../$UNZIPDIR/src/druntime/import/ usr/include/dmd/druntime/
 	# remove unneeded folder
 	rm -rf usr/include/dmd/phobos/etc/c/zlib

--- a/linux/dmd_rpm.sh
+++ b/linux/dmd_rpm.sh
@@ -195,7 +195,7 @@ do
 
 		# install include
 		mkdir -p usr/include/dmd/{phobos,druntime}
-		cp -Rf ../$UNZIPDIR/src/phobos/{std,etc} usr/include/dmd/phobos/
+		cp -Rf ../$UNZIPDIR/src/phobos/{std,etc,phobos} usr/include/dmd/phobos/
 		cp -Rf ../$UNZIPDIR/src/druntime/import/ usr/include/dmd/druntime/
 		# remove unneeded folder
 		rm -rf usr/include/dmd/phobos/etc/c/zlib


### PR DESCRIPTION
The Phobos V3 directory is already included on Windows and MacOS. This pull brings Linux up to parity.